### PR TITLE
Add soft character limit for writable book pages

### DIFF
--- a/src/item/WritableBookPage.php
+++ b/src/item/WritableBookPage.php
@@ -31,6 +31,7 @@ use function strlen;
 class WritableBookPage{
 	public const PAGE_LENGTH_HARD_LIMIT_BYTES = Limits::INT16_MAX;
 	public const PHOTO_NAME_LENGTH_HARD_LIMIT_BYTES = Limits::INT16_MAX;
+	public const PAGE_LENGTH_SOFT_LIMIT_CHARS = 512; // Experimental limit
 
 	private string $text;
 	private string $photoName;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -986,7 +986,7 @@ class InGamePacketHandler extends PacketHandler
 		$cancel = false;
 		switch ($packet->type) {
 			case BookEditPacket::TYPE_REPLACE_PAGE:
-				$text = self::checkBookText($packet->text, "page text", 256, WritableBookPage::PAGE_LENGTH_HARD_LIMIT_BYTES, $cancel);
+				$text = self::checkBookText($packet->text, "page text", WritableBookPage::PAGE_LENGTH_SOFT_LIMIT_CHARS, WritableBookPage::PAGE_LENGTH_HARD_LIMIT_BYTES, $cancel);
 				$newBook->setPageText($packet->pageNumber, $text);
 				$modifiedPages[] = $packet->pageNumber;
 				break;
@@ -996,7 +996,7 @@ class InGamePacketHandler extends PacketHandler
 					//TODO: the client can send insert-before actions on trailing client-side pages which cause odd behaviour on the server
 					return false;
 				}
-				$text = self::checkBookText($packet->text, "page text", 256, WritableBookPage::PAGE_LENGTH_HARD_LIMIT_BYTES, $cancel);
+				$text = self::checkBookText($packet->text, "page text", WritableBookPage::PAGE_LENGTH_SOFT_LIMIT_CHARS, WritableBookPage::PAGE_LENGTH_HARD_LIMIT_BYTES, $cancel);
 				$newBook->insertPage($packet->pageNumber, $text);
 				$modifiedPages[] = $packet->pageNumber;
 				break;


### PR DESCRIPTION
Introduces an experimental soft limit of 512 characters for writable book pages and updates packet handling to use this limit when validating page text. This change aims to improve user experience and prevent excessively long page entries.
