### PR TITLE
Implemented Spear

### DIFF
--- a/changelogs/5.41.2.md
+++ b/changelogs/5.41.2.md
@@ -1,0 +1,27 @@
+# 5.41.2
+Released 5th April 2026.
+
+This release introduces Bundle support.
+
+## General
+- Implemented bundles.
+- Added the `Bundle` item and in-item storage support with `BundleInventory`.
+- Added inventory-aware item hooks via `InventoryAwareItem`.
+- Registered bundle item IDs and updated `VanillaItems` / `VanillaItemsInputs` mappings.
+- Updated Bedrock item serializer/deserializer registrations for bundle handling.
+- Bumped base version to `5.41.2`.
+
+## Inventory and networking
+- Added dynamic container handling for bundle storage in `InventoryManager`.
+- Updated stack request execution/response flow to correctly resolve dynamic container slots.
+- Added bundle interaction sounds for insert, insert-fail, remove-one and drop-contents actions.
+- Improved tracked itemstack handling to reduce mismatch/desync risks during bundle moves.
+
+## Internal changes
+- Added `getUnclonedItem()` support across inventory implementations (`BaseInventory`, `SimpleInventory`, `DelegateInventory`, `DoubleChestInventory`, `TransactionBuilderInventory`) to avoid unnecessary cloning in internal operations.
+- Added internal inventory updates to correctly trigger inventory-aware item callbacks.
+
+## References
+- Commit: `48feb81d4039f189fb9cd12246fb2c48221e0e54`
+- PR: `#31`
+- Title: `Implemented bundles`

--- a/changelogs/5.41.3.md
+++ b/changelogs/5.41.3.md
@@ -1,0 +1,43 @@
+# 5.41.3
+Released 5th April 2026.
+
+This release focuses on spear combat and enchantment support.
+
+## Spear enchantments
+- Spears can now receive and use weapon enchantments in normal workflows (enchanting/anvil/command parsing).
+- Added and wired support for spear usage with:
+  - Sharpness
+  - Smite
+  - Bane of Arthropods
+  - Looting
+  - Knockback
+  - Fire Aspect
+  - Lunge
+  - Unbreaking
+  - Mending
+  - Curse of Vanishing
+- Added incompatibility wiring for damage-family weapon enchantments (Sharpness/Smite/Bane) so conflict rules are respected.
+- Updated enchant parser and Bedrock ID mappings for newly wired enchantments.
+
+## Lunge on spear jab
+- Lunge now activates on spear jab and propels the player forward.
+- Lunge consumption scales by enchant level:
+  - Level I: consumes 1 point
+  - Level II: consumes 2 points
+  - Level III: consumes 3 points
+- Consumption order follows vanilla-like behavior:
+  - Saturation is consumed first.
+  - Hunger is consumed after saturation.
+- Lunge additionally consumes 1 spear durability when activated.
+- Lunge is blocked when conditions are invalid:
+  - Player has less than 6 hunger points.
+  - Player is underwater/swimming.
+  - Player is gliding.
+  - Player is in water.
+
+## Drops and combat integration
+- Connected Looting into relevant drop paths so spear kills benefit from looting level.
+- Applied target-type damage hooks for Smite (undead) and Bane of Arthropods (arthropods), including Bane slow effect behavior.
+
+## Notes
+- Spear jab + immediate follow-up charge now benefits from Lunge velocity, improving connect potential at medium distance.

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,7 +31,7 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "beeltymine-mp";
-	public const BASE_VERSION = "5.41.1";
+	public const BASE_VERSION = "5.41.3";
 	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 	public const GITHUB_URL = "https://github.com/BeeltyMine/BeeltyMine-MP";

--- a/src/data/bedrock/EnchantmentIdMap.php
+++ b/src/data/bedrock/EnchantmentIdMap.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
 
 declare(strict_types=1);
@@ -46,10 +46,12 @@ final class EnchantmentIdMap{
 		$this->register(EnchantmentIds::AQUA_AFFINITY, VanillaEnchantments::AQUA_AFFINITY());
 
 		$this->register(EnchantmentIds::SHARPNESS, VanillaEnchantments::SHARPNESS());
-		//TODO: smite, bane of arthropods (these don't make sense now because their applicable mobs don't exist yet)
+		$this->register(EnchantmentIds::SMITE, VanillaEnchantments::SMITE());
+		$this->register(EnchantmentIds::BANE_OF_ARTHROPODS, VanillaEnchantments::BANE_OF_ARTHROPODS());
 
 		$this->register(EnchantmentIds::KNOCKBACK, VanillaEnchantments::KNOCKBACK());
 		$this->register(EnchantmentIds::FIRE_ASPECT, VanillaEnchantments::FIRE_ASPECT());
+		$this->register(EnchantmentIds::LOOTING, VanillaEnchantments::LOOTING());
 
 		$this->register(EnchantmentIds::EFFICIENCY, VanillaEnchantments::EFFICIENCY());
 		$this->register(EnchantmentIds::FORTUNE, VanillaEnchantments::FORTUNE());
@@ -66,6 +68,7 @@ final class EnchantmentIdMap{
 		$this->register(EnchantmentIds::VANISHING, VanillaEnchantments::VANISHING());
 
 		$this->register(EnchantmentIds::SWIFT_SNEAK, VanillaEnchantments::SWIFT_SNEAK());
+		$this->register(EnchantmentIds::LUNGE, VanillaEnchantments::LUNGE());
 
 		$this->register(EnchantmentIds::FROST_WALKER, VanillaEnchantments::FROST_WALKER());
 	}

--- a/src/data/bedrock/EnchantmentIds.php
+++ b/src/data/bedrock/EnchantmentIds.php
@@ -1,23 +1,25 @@
 <?php
 
+
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
+
 
 declare(strict_types=1);
 
@@ -67,4 +69,5 @@ final class EnchantmentIds{
 	public const QUICK_CHARGE = 35;
 	public const SOUL_SPEED = 36;
 	public const SWIFT_SNEAK = 37;
+	public const LUNGE = 41;
 }

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -228,6 +228,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::COPPER_LEGGINGS, Items::COPPER_LEGGINGS());
 		$this->map1to1Item(Ids::COPPER_NUGGET, Items::COPPER_NUGGET());
 		$this->map1to1Item(Ids::COPPER_PICKAXE, Items::COPPER_PICKAXE());
+		$this->map1to1Item(Ids::COPPER_SPEAR, Items::COPPER_SPEAR());
 		$this->map1to1Item(Ids::COPPER_SHOVEL, Items::COPPER_SHOVEL());
 		$this->map1to1Item(Ids::COPPER_SWORD, Items::COPPER_SWORD());
 		$this->map1to1Item(Ids::CRIMSON_HANGING_SIGN, Items::CRIMSON_HANGING_SIGN());
@@ -243,6 +244,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::DIAMOND_HOE, Items::DIAMOND_HOE());
 		$this->map1to1Item(Ids::DIAMOND_LEGGINGS, Items::DIAMOND_LEGGINGS());
 		$this->map1to1Item(Ids::DIAMOND_PICKAXE, Items::DIAMOND_PICKAXE());
+		$this->map1to1Item(Ids::DIAMOND_SPEAR, Items::DIAMOND_SPEAR());
 		$this->map1to1Item(Ids::DIAMOND_SHOVEL, Items::DIAMOND_SHOVEL());
 		$this->map1to1Item(Ids::DIAMOND_SWORD, Items::DIAMOND_SWORD());
 		$this->map1to1Item(Ids::DISC_FRAGMENT_5, Items::DISC_FRAGMENT_5());
@@ -283,6 +285,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::GOLDEN_HOE, Items::GOLDEN_HOE());
 		$this->map1to1Item(Ids::GOLDEN_LEGGINGS, Items::GOLDEN_LEGGINGS());
 		$this->map1to1Item(Ids::GOLDEN_PICKAXE, Items::GOLDEN_PICKAXE());
+		$this->map1to1Item(Ids::GOLDEN_SPEAR, Items::GOLDEN_SPEAR());
 		$this->map1to1Item(Ids::GOLDEN_SHOVEL, Items::GOLDEN_SHOVEL());
 		$this->map1to1Item(Ids::GOLDEN_SWORD, Items::GOLDEN_SWORD());
 		$this->map1to1Item(Ids::GUNPOWDER, Items::GUNPOWDER());
@@ -301,6 +304,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::IRON_LEGGINGS, Items::IRON_LEGGINGS());
 		$this->map1to1Item(Ids::IRON_NUGGET, Items::IRON_NUGGET());
 		$this->map1to1Item(Ids::IRON_PICKAXE, Items::IRON_PICKAXE());
+		$this->map1to1Item(Ids::IRON_SPEAR, Items::IRON_SPEAR());
 		$this->map1to1Item(Ids::IRON_SHOVEL, Items::IRON_SHOVEL());
 		$this->map1to1Item(Ids::IRON_SWORD, Items::IRON_SWORD());
 		$this->map1to1Item(Ids::JUNGLE_BOAT, Items::JUNGLE_BOAT());
@@ -357,6 +361,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::NETHERITE_PICKAXE, Items::NETHERITE_PICKAXE());
 		$this->map1to1Item(Ids::NETHERITE_SCRAP, Items::NETHERITE_SCRAP());
 		$this->map1to1Item(Ids::NETHERITE_SHOVEL, Items::NETHERITE_SHOVEL());
+		$this->map1to1Item(Ids::NETHERITE_SPEAR, Items::NETHERITE_SPEAR());
 		$this->map1to1Item(Ids::NETHERITE_SWORD, Items::NETHERITE_SWORD());
 		$this->map1to1Item(Ids::NETHERITE_UPGRADE_SMITHING_TEMPLATE, Items::NETHERITE_UPGRADE_SMITHING_TEMPLATE());
 		$this->map1to1Item(Ids::OAK_BOAT, Items::OAK_BOAT());
@@ -413,6 +418,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::STONE_HOE, Items::STONE_HOE());
 		$this->map1to1Item(Ids::STONE_PICKAXE, Items::STONE_PICKAXE());
 		$this->map1to1Item(Ids::STONE_SHOVEL, Items::STONE_SHOVEL());
+		$this->map1to1Item(Ids::STONE_SPEAR, Items::STONE_SPEAR());
 		$this->map1to1Item(Ids::STONE_SWORD, Items::STONE_SWORD());
 		$this->map1to1Item(Ids::STRING, Items::STRING());
 		$this->map1to1Item(Ids::SUGAR, Items::SUGAR());
@@ -437,6 +443,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::WOODEN_HOE, Items::WOODEN_HOE());
 		$this->map1to1Item(Ids::WOODEN_PICKAXE, Items::WOODEN_PICKAXE());
 		$this->map1to1Item(Ids::WOODEN_SHOVEL, Items::WOODEN_SHOVEL());
+		$this->map1to1Item(Ids::WOODEN_SPEAR, Items::WOODEN_SPEAR());
 		$this->map1to1Item(Ids::WOODEN_SWORD, Items::WOODEN_SWORD());
 		$this->map1to1Item(Ids::WRITABLE_BOOK, Items::WRITABLE_BOOK());
 		$this->map1to1Item(Ids::WRITTEN_BOOK, Items::WRITTEN_BOOK());

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -803,6 +803,20 @@ abstract class Living extends Entity{
 	}
 
 	/**
+	 * Returns whether this entity is considered undead for enchantment interactions (e.g. Smite).
+	 */
+	public function isUndead() : bool{
+		return false;
+	}
+
+	/**
+	 * Returns whether this entity is considered an arthropod for enchantment interactions (e.g. Bane of Arthropods).
+	 */
+	public function isArthropod() : bool{
+		return false;
+	}
+
+	/**
 	 * Returns whether the entity is currently breathing or not. If this is false, the entity's air supply will be used.
 	 */
 	public function isBreathing() : bool{
@@ -863,6 +877,23 @@ abstract class Living extends Entity{
 	 */
 	public function getDrops() : array{
 		return [];
+	}
+
+	/**
+	 * Returns the looting level on the weapon used by the player that most recently damaged this entity.
+	 */
+	protected function getLootingLevelForDrops() : int{
+		$lastDamageCause = $this->getLastDamageCause();
+		if(!$lastDamageCause instanceof EntityDamageByEntityEvent){
+			return 0;
+		}
+
+		$damager = $lastDamageCause->getDamager();
+		if(!$damager instanceof Player){
+			return 0;
+		}
+
+		return $damager->getInventory()->getItemInHand()->getEnchantmentLevel(VanillaEnchantments::LOOTING());
 	}
 
 	/**

--- a/src/entity/Squid.php
+++ b/src/entity/Squid.php
@@ -121,8 +121,10 @@ class Squid extends WaterAnimal{
 	}
 
 	public function getDrops() : array{
+		$looting = $this->getLootingLevelForDrops();
+
 		return [
-			VanillaItems::INK_SAC()->setCount(mt_rand(1, 3))
+			VanillaItems::INK_SAC()->setCount(mt_rand(1, 3 + $looting))
 		];
 	}
 

--- a/src/entity/Zombie.php
+++ b/src/entity/Zombie.php
@@ -40,12 +40,18 @@ class Zombie extends Living{
 		return "Zombie";
 	}
 
+	public function isUndead() : bool{
+		return true;
+	}
+
 	public function getDrops() : array{
+		$looting = $this->getLootingLevelForDrops();
+
 		$drops = [
-			VanillaItems::ROTTEN_FLESH()->setCount(mt_rand(0, 2))
+			VanillaItems::ROTTEN_FLESH()->setCount(mt_rand(0, 2 + $looting))
 		];
 
-		if(mt_rand(0, 199) < 5){
+		if(mt_rand(0, 199) < (5 + $looting * 5)){
 			switch(mt_rand(0, 2)){
 				case 0:
 					$drops[] = VanillaItems::IRON_INGOT();

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -613,6 +613,13 @@ class Item implements \JsonSerializable{
 	}
 
 	/**
+	 * Called every tick while the player is using this item.
+	 */
+	public function whileUsing(Player $player) : void{
+		//NOOP
+	}
+
+	/**
 	 * Called when a player is using this item and releases it. Used to handle bow shoot actions.
 	 * Returns whether the item was changed, for example count decrease or durability change.
 	 *

--- a/src/item/ItemCooldownTags.php
+++ b/src/item/ItemCooldownTags.php
@@ -42,4 +42,5 @@ final class ItemCooldownTags{
 	public const ENDER_PEARL = "ender_pearl";
 	public const SHIELD = "shield";
 	public const GOAT_HORN = "goat_horn";
+	public const SPEAR = "spear";
 }

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -363,8 +363,15 @@ final class ItemTypeIds{
 	public const BAMBOO_HANGING_SIGN = 20324;
 	public const BAMBOO_SIGN = 20325;
 	public const ELYTRA = 20326;
+	public const WOODEN_SPEAR = 20327;
+	public const STONE_SPEAR = 20328;
+	public const COPPER_SPEAR = 20329;
+	public const IRON_SPEAR = 20330;
+	public const GOLDEN_SPEAR = 20331;
+	public const DIAMOND_SPEAR = 20332;
+	public const NETHERITE_SPEAR = 20333;
 
-	public const FIRST_UNUSED_ITEM_ID = 20327;
+	public const FIRST_UNUSED_ITEM_ID = 20334;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_ITEM_ID;
 

--- a/src/item/Spear.php
+++ b/src/item/Spear.php
@@ -1,0 +1,459 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+use pocketmine\block\Block;
+use pocketmine\block\Water;
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\item\enchantment\VanillaEnchantments;
+use pocketmine\math\AxisAlignedBB;
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+use pocketmine\player\Player;
+use pocketmine\world\sound\SimpleLevelSound;
+use pocketmine\world\sound\Sound;
+use function floor;
+use function max;
+
+class Spear extends TieredTool implements Releasable{
+	private const ATTACK_POINT_OFFSET = 2;
+	private const STAB_COOLDOWN_TICKS = 20;
+	private const HOLD_HIT_COOLDOWN_TICKS = 10;
+	private const HOLD_HITBOX_GROW_XZ = 1.5;
+	private const HOLD_HITBOX_GROW_Y = 1.0;
+	private const HOLD_FORWARD_OFFSET = 1.5;
+	private const HOLD_DAMAGE_MULTIPLIER_ENGAGED = 1.0;
+	private const HOLD_DAMAGE_MULTIPLIER_TIRED = 1.0;
+	private const HOLD_DAMAGE_MULTIPLIER_DISENGAGED = 1.0;
+	private const MINIMUM_CHARGE_RELATIVE_SPEED = 0.255; // 5.1 blocks/second
+	private const CHARGE_STAGE_ENGAGED_MAX_TICKS = 10;
+	private const CHARGE_STAGE_TIRED_MAX_TICKS = 20;
+	private const CHARGE_KNOCKBACK_ENGAGED = 0.5;
+	private const CHARGE_KNOCKBACK_TIRED = 0.35;
+	private const CHARGE_KNOCKBACK_DISENGAGED = 0.0;
+	private const CHARGE_TARGET_MIN_DOT = 0.7;
+	private const CHARGE_TARGET_HITBOX_MARGIN = 0.125;
+	private const JAB_MAX_DISTANCE = 4.5;
+	private const JAB_MIN_DISTANCE = 2.0;
+	private const JAB_HITBOX_MARGIN = 0.125;
+	private const LUNGE_HORIZONTAL_BOOST_PER_LEVEL = 0.458;
+	private const LUNGE_EXHAUSTION_PER_LEVEL = 4.0;
+	private const LUNGE_MIN_FOOD = 6.0;
+	private const STAB_MAX_DISTANCE = 5.0;
+	private const STAB_MIN_DOT = 0.866;
+	private const MINIMUM_STAB_SPEED = 0.13;
+
+	/** @var array<int, int> maps player ID => next tick when charge can connect again */
+	private static array $chargeConnectionCooldownUntil = [];
+	/** @var array<int, Vector3> maps player ID => last sampled position for charge speed */
+	private static array $lastChargeSamplePosition = [];
+	/** @var array<int, int> maps player ID => last sampled tick for charge speed */
+	private static array $lastChargeSampleTick = [];
+
+	public function getAttackPoints() : int{
+		return max(1, $this->tier->getBaseAttackPoints() - self::ATTACK_POINT_OFFSET);
+	}
+
+	public function onClickAir(Player $player, Vector3 $directionVector, array &$returnedItems) : ItemUseResult{
+		$player->getWorld()->addSound($player->getPosition(), $this->getUseSound());
+		return ItemUseResult::SUCCESS;
+	}
+
+	public function getCooldownTicks() : int{
+		// Keep jab/charge cooldown handling manual to avoid delaying charge-start on right-click use.
+		return 0;
+	}
+
+	public function getJabCooldownTicks() : int{
+		return self::STAB_COOLDOWN_TICKS;
+	}
+
+	public function getCooldownTag() : ?string{
+		return ItemCooldownTags::SPEAR;
+	}
+
+	public function canStartUsingItem(Player $player) : bool{
+		return true;
+	}
+
+	public function getJabMaxDistance() : float{
+		return self::JAB_MAX_DISTANCE;
+	}
+
+	public function getJabMinDistance() : float{
+		return self::JAB_MIN_DISTANCE;
+	}
+
+	public function getJabHitboxMargin() : float{
+		return self::JAB_HITBOX_MARGIN;
+	}
+
+	public function getLungeLevel() : int{
+		return $this->getEnchantmentLevel(VanillaEnchantments::LUNGE());
+	}
+
+	public function activateLunge(Player $player) : bool{
+		$lungeLevel = $this->getLungeLevel();
+		if(!$this->canActivateLunge($player, $lungeLevel)){
+			return false;
+		}
+
+		$direction = $player->getDirectionVector()->withComponents(null, 0.0, null);
+		if($direction->lengthSquared() <= 0){
+			return false;
+		}
+
+		$boost = $direction
+			->normalize()
+			->multiply(self::LUNGE_HORIZONTAL_BOOST_PER_LEVEL * $lungeLevel);
+		$player->setMotion($player->getMotion()->addVector($boost));
+		$player->getWorld()->addSound($player->getPosition(), new SimpleLevelSound($this->getLungeSoundEventId($lungeLevel)));
+
+		if($player->isSurvival(true) || $player->isAdventure(true)){
+			$player->getHungerManager()->exhaust(self::LUNGE_EXHAUSTION_PER_LEVEL * $lungeLevel, PlayerExhaustEvent::CAUSE_ATTACK);
+		}
+
+		return true;
+	}
+
+	private function canActivateLunge(Player $player, int $lungeLevel) : bool{
+		if($lungeLevel <= 0){
+			return false;
+		}
+
+		if($player->isGliding() || $player->isSwimming() || $player->isUnderwater()){
+			return false;
+		}
+
+		$position = $player->getPosition();
+		$x = (int) floor($position->x);
+		$y = (int) floor($position->y);
+		$z = (int) floor($position->z);
+		$world = $player->getWorld();
+ 
+		if($world->getBlockAt($x, $y, $z) instanceof Water || $world->getBlockAt($x, $y - 1, $z) instanceof Water){
+			return false;
+		}
+
+		if(($player->isSurvival(true) || $player->isAdventure(true)) && $player->getHungerManager()->getFood() < self::LUNGE_MIN_FOOD){
+			return false;
+		}
+
+		return true;
+	}
+
+	public function whileUsing(Player $player) : void{
+		$playerVelocity = $this->sampleChargeVelocity($player);
+
+		if(!$this->canConnectChargeHit($player)){
+			return;
+		}
+
+		$world = $player->getWorld();
+		[$damageMultiplier, $knockBack] = $this->getChargeStageCombatValues($player->getItemUseDuration());
+
+		$lookDirection = $player->getDirectionVector()->normalize();
+		$direction = $lookDirection->multiply(self::HOLD_FORWARD_OFFSET);
+		$hitBox = $player->getBoundingBox()
+			->expandedCopy(self::HOLD_HITBOX_GROW_XZ, self::HOLD_HITBOX_GROW_Y, self::HOLD_HITBOX_GROW_XZ)
+			->offset($direction->x, $direction->y, $direction->z);
+		$targets = $this->findChargeTargets($player, $lookDirection, $hitBox);
+		if(count($targets) === 0){
+			return;
+		}
+
+		$didHit = false;
+		$playerPos = $player->getPosition();
+		foreach($targets as $target){
+			$targetPos = $target->getPosition()->add(0, $target->size->getHeight() / 2, 0);
+			$toTarget = $targetPos->subtractVector($playerPos)->normalize();
+			$relativeVelocity = $playerVelocity->subtractVector($target->getMotion());
+
+			$closingSpeed = $relativeVelocity->dot($toTarget);
+			if($closingSpeed < self::MINIMUM_CHARGE_RELATIVE_SPEED){
+				continue;
+			}
+
+			$relativeSpeedBps = $relativeVelocity->length() * 20;
+			$finalDamage = max(1.0, $relativeSpeedBps * $this->getChargeSpeedDamageMultiplier() * $damageMultiplier);
+			$damageEvent = new EntityDamageByEntityEvent(
+				$player,
+				$target,
+				EntityDamageEvent::CAUSE_ENTITY_ATTACK,
+				$finalDamage
+			);
+			$damageEvent->setModifier(0.0, EntityDamageEvent::MODIFIER_STRENGTH);
+			$damageEvent->setModifier(0.0, EntityDamageEvent::MODIFIER_WEAKNESS);
+			$damageEvent->setKnockBack($knockBack);
+			$target->attack($damageEvent);
+			if(!$damageEvent->isCancelled()){
+				$didHit = true;
+			}
+		}
+
+		if($didHit){
+			$this->setChargeConnectionCooldown($player);
+			$world->addSound($player->getPosition(), $this->getAttackHitSound());
+		}
+	}
+
+	private function getChargeSpeedDamageMultiplier() : float{
+		return match($this->tier){
+			ToolTier::WOOD, ToolTier::GOLD => 0.7,
+			ToolTier::STONE, ToolTier::COPPER => 0.82,
+			ToolTier::IRON => 0.95,
+			ToolTier::DIAMOND => 1.075,
+			ToolTier::NETHERITE => 1.2,
+		};
+	}
+
+	/**
+	 * @return Living[]
+	 */
+	private function findChargeTargets(Player $player, Vector3 $lookDirection, AxisAlignedBB $hitBox) : array{
+		$eyePos = $player->getEyePos();
+		$traceEnd = $eyePos->addVector($lookDirection->multiply(self::JAB_MAX_DISTANCE));
+		$candidates = [];
+		foreach($player->getWorld()->getNearbyEntities($hitBox, $player) as $entity){
+			if(!$entity instanceof Living || !$entity->isAlive()){
+				continue;
+			}
+
+			$targetPos = $entity->getPosition()->add(0, $entity->size->getHeight() / 2, 0);
+			$distance = $eyePos->distance($targetPos);
+			if($distance > self::JAB_MAX_DISTANCE){
+				continue;
+			}
+
+			$expandedHitBox = $entity->getBoundingBox()->expandedCopy(self::CHARGE_TARGET_HITBOX_MARGIN, self::CHARGE_TARGET_HITBOX_MARGIN, self::CHARGE_TARGET_HITBOX_MARGIN);
+			$toTarget = $targetPos->subtractVector($eyePos)->normalize();
+			$dot = $lookDirection->dot($toTarget);
+			if($dot < self::CHARGE_TARGET_MIN_DOT){
+				continue;
+			}
+
+			if($expandedHitBox->calculateIntercept($eyePos, $traceEnd) === null){
+				continue;
+			}
+
+			$score = $dot - ($distance / self::JAB_MAX_DISTANCE) * 0.15;
+			$candidates[] = [
+				"entity" => $entity,
+				"score" => $score,
+			];
+		}
+
+		usort($candidates, static fn(array $a, array $b) : int => $b["score"] <=> $a["score"]);
+
+		$targets = [];
+		foreach($candidates as $candidate){
+			$targets[] = $candidate["entity"];
+		}
+
+		return $targets;
+	}
+
+	private function sampleChargeVelocity(Player $player) : Vector3{
+		$playerId = $player->getId();
+		$currentTick = $player->getServer()->getTick();
+		$currentPosition = $player->getPosition();
+
+		$lastPosition = self::$lastChargeSamplePosition[$playerId] ?? null;
+		$lastTick = self::$lastChargeSampleTick[$playerId] ?? null;
+
+		self::$lastChargeSamplePosition[$playerId] = $currentPosition;
+		self::$lastChargeSampleTick[$playerId] = $currentTick;
+
+		if($lastPosition === null || $lastTick === null || $currentTick <= $lastTick){
+			return Vector3::zero();
+		}
+
+		$tickDelta = $currentTick - $lastTick;
+		return $currentPosition->subtractVector($lastPosition)->divide((float) $tickDelta);
+	}
+
+	private function canConnectChargeHit(Player $player) : bool{
+		return (self::$chargeConnectionCooldownUntil[$player->getId()] ?? 0) <= $player->getServer()->getTick();
+	}
+
+	private function setChargeConnectionCooldown(Player $player) : void{
+		self::$chargeConnectionCooldownUntil[$player->getId()] = $player->getServer()->getTick() + self::HOLD_HIT_COOLDOWN_TICKS;
+	}
+
+	/**
+	 * @return array{float, float} [damageMultiplier, knockback]
+	 */
+	private function getChargeStageCombatValues(int $useDuration) : array{
+		if($useDuration < self::CHARGE_STAGE_ENGAGED_MAX_TICKS){
+			return [self::HOLD_DAMAGE_MULTIPLIER_ENGAGED, self::CHARGE_KNOCKBACK_ENGAGED];
+		}
+
+		if($useDuration < self::CHARGE_STAGE_TIRED_MAX_TICKS){
+			return [self::HOLD_DAMAGE_MULTIPLIER_TIRED, self::CHARGE_KNOCKBACK_TIRED];
+		}
+
+		return [self::HOLD_DAMAGE_MULTIPLIER_DISENGAGED, self::CHARGE_KNOCKBACK_DISENGAGED];
+	}
+
+	/**
+	 * @param Item[] &$returnedItems
+	 */
+	public function onSpearStab(Player $player, float $movementSpeed, array &$returnedItems) : void{
+		if($player->hasItemCooldown($this)){
+			return;
+		}
+
+		$world = $player->getWorld();
+		$player->resetItemCooldown($this, self::STAB_COOLDOWN_TICKS);
+		$world->addSound($player->getPosition(), $this->getUseSound());
+
+		if($movementSpeed < self::MINIMUM_STAB_SPEED || !$player->isSprinting()){
+			$world->addSound($player->getPosition(), $this->getMissSound());
+			return;
+		}
+
+		$eyePos = $player->getEyePos();
+		$direction = $player->getDirectionVector()->normalize();
+		$searchBox = $player->getBoundingBox()->expandedCopy(self::STAB_MAX_DISTANCE, self::STAB_MAX_DISTANCE, self::STAB_MAX_DISTANCE);
+
+		$bestScore = -1.0;
+		$target = null;
+
+		foreach($world->getNearbyEntities($searchBox, $player) as $entity){
+			if(!$entity instanceof Living || !$entity->isAlive()){
+				continue;
+			}
+
+			$targetPos = $entity->getPosition()->add(0, $entity->getEyeHeight() * 0.5, 0);
+			$distance = $eyePos->distance($targetPos);
+			if($distance > self::STAB_MAX_DISTANCE){
+				continue;
+			}
+
+			$toEntity = $targetPos->subtractVector($eyePos)->normalize();
+			$dot = $direction->dot($toEntity);
+			if($dot < self::STAB_MIN_DOT){
+				continue;
+			}
+
+			$score = $dot - ($distance / self::STAB_MAX_DISTANCE) * 0.1;
+			if($score <= $bestScore){
+				continue;
+			}
+
+			$bestScore = $score;
+			$target = $entity;
+		}
+
+		if($target !== null){
+			$damageEvent = new EntityDamageByEntityEvent(
+				$player,
+				$target,
+				EntityDamageEvent::CAUSE_ENTITY_ATTACK,
+				$this->getAttackPoints()
+			);
+			$target->attack($damageEvent);
+
+			if(!$damageEvent->isCancelled()){
+				$this->onAttackEntity($target, $returnedItems);
+				$world->addSound($player->getPosition(), $this->getAttackHitSound());
+				return;
+			}
+		}
+
+		$world->addSound($player->getPosition(), $this->getMissSound());
+	}
+
+	public function onDestroyBlock(Block $block, array &$returnedItems) : bool{
+		if(!$block->getBreakInfo()->breaksInstantly()){
+			return $this->applyDamage(2);
+		}
+
+		return false;
+	}
+
+	public function onAttackEntity(Entity $victim, array &$returnedItems) : bool{
+		return $this->applyDamage(1);
+	}
+
+	public function getAttackHitSound() : Sound{
+		return new SimpleLevelSound($this->getHitSoundEventId());
+	}
+
+	public function getUseSound() : Sound{
+		return new SimpleLevelSound($this->getUseSoundEventId());
+	}
+
+	public function getMissSound() : Sound{
+		return new SimpleLevelSound($this->getMissSoundEventId());
+	}
+
+	private function getHitSoundEventId() : int{
+		return match($this->tier){
+			ToolTier::WOOD => LevelSoundEvent::ITEM_WOODEN_SPEAR_ATTACK_HIT,
+			ToolTier::STONE => LevelSoundEvent::ITEM_STONE_SPEAR_ATTACK_HIT,
+			ToolTier::COPPER => LevelSoundEvent::ITEM_COPPER_SPEAR_ATTACK_HIT,
+			ToolTier::IRON => LevelSoundEvent::ITEM_IRON_SPEAR_ATTACK_HIT,
+			ToolTier::GOLD => LevelSoundEvent::ITEM_GOLDEN_SPEAR_ATTACK_HIT,
+			ToolTier::DIAMOND => LevelSoundEvent::ITEM_DIAMOND_SPEAR_ATTACK_HIT,
+			ToolTier::NETHERITE => LevelSoundEvent::ITEM_NETHERITE_SPEAR_ATTACK_HIT,
+		};
+	}
+
+	private function getUseSoundEventId() : int{
+		return match($this->tier){
+			ToolTier::WOOD => LevelSoundEvent::ITEM_WOODEN_SPEAR_USE,
+			ToolTier::STONE => LevelSoundEvent::ITEM_STONE_SPEAR_USE,
+			ToolTier::COPPER => LevelSoundEvent::ITEM_COPPER_SPEAR_USE,
+			ToolTier::IRON => LevelSoundEvent::ITEM_IRON_SPEAR_USE,
+			ToolTier::GOLD => LevelSoundEvent::ITEM_GOLDEN_SPEAR_USE,
+			ToolTier::DIAMOND => LevelSoundEvent::ITEM_DIAMOND_SPEAR_USE,
+			ToolTier::NETHERITE => LevelSoundEvent::ITEM_NETHERITE_SPEAR_USE,
+		};
+	}
+
+	private function getMissSoundEventId() : int{
+		return match($this->tier){
+			ToolTier::WOOD => LevelSoundEvent::ITEM_WOODEN_SPEAR_ATTACK_MISS,
+			ToolTier::STONE => LevelSoundEvent::ITEM_STONE_SPEAR_ATTACK_MISS,
+			ToolTier::COPPER => LevelSoundEvent::ITEM_COPPER_SPEAR_ATTACK_MISS,
+			ToolTier::IRON => LevelSoundEvent::ITEM_IRON_SPEAR_ATTACK_MISS,
+			ToolTier::GOLD => LevelSoundEvent::ITEM_GOLDEN_SPEAR_ATTACK_MISS,
+			ToolTier::DIAMOND => LevelSoundEvent::ITEM_DIAMOND_SPEAR_ATTACK_MISS,
+			ToolTier::NETHERITE => LevelSoundEvent::ITEM_NETHERITE_SPEAR_ATTACK_MISS,
+		};
+	}
+
+	private function getLungeSoundEventId(int $lungeLevel) : int{
+		return match($lungeLevel){
+			1 => LevelSoundEvent::ITEM_ENCHANT_LUNGE1,
+			2 => LevelSoundEvent::ITEM_ENCHANT_LUNGE2,
+			default => LevelSoundEvent::ITEM_ENCHANT_LUNGE3,
+		};
+	}
+}

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1401,6 +1401,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("copper_leggings", fn() => Items::COPPER_LEGGINGS());
 		$result->register("copper_nugget", fn() => Items::COPPER_NUGGET());
 		$result->register("copper_pickaxe", fn() => Items::COPPER_PICKAXE());
+		$result->register("copper_spear", fn() => Items::COPPER_SPEAR());
 		$result->register("copper_shovel", fn() => Items::COPPER_SHOVEL());
 		$result->register("copper_sword", fn() => Items::COPPER_SWORD());
 		$result->register("crimson_hanging_sign", fn() => Items::CRIMSON_HANGING_SIGN());
@@ -1414,6 +1415,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("diamond_hoe", fn() => Items::DIAMOND_HOE());
 		$result->register("diamond_leggings", fn() => Items::DIAMOND_LEGGINGS());
 		$result->register("diamond_pickaxe", fn() => Items::DIAMOND_PICKAXE());
+		$result->register("diamond_spear", fn() => Items::DIAMOND_SPEAR());
 		$result->register("diamond_shovel", fn() => Items::DIAMOND_SHOVEL());
 		$result->register("diamond_sword", fn() => Items::DIAMOND_SWORD());
 		$result->register("disc_fragment_5", fn() => Items::DISC_FRAGMENT_5());
@@ -1473,6 +1475,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("golden_leggings", fn() => Items::GOLDEN_LEGGINGS());
 		$result->register("golden_nugget", fn() => Items::GOLD_NUGGET());
 		$result->register("golden_pickaxe", fn() => Items::GOLDEN_PICKAXE());
+		$result->register("golden_spear", fn() => Items::GOLDEN_SPEAR());
 		$result->register("golden_shovel", fn() => Items::GOLDEN_SHOVEL());
 		$result->register("golden_sword", fn() => Items::GOLDEN_SWORD());
 		$result->register("gunpowder", fn() => Items::GUNPOWDER());
@@ -1491,6 +1494,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("iron_leggings", fn() => Items::IRON_LEGGINGS());
 		$result->register("iron_nugget", fn() => Items::IRON_NUGGET());
 		$result->register("iron_pickaxe", fn() => Items::IRON_PICKAXE());
+		$result->register("iron_spear", fn() => Items::IRON_SPEAR());
 		$result->register("iron_shovel", fn() => Items::IRON_SHOVEL());
 		$result->register("iron_sword", fn() => Items::IRON_SWORD());
 		$result->register("jungle_boat", fn() => Items::JUNGLE_BOAT());
@@ -1533,6 +1537,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("netherite_leggings", fn() => Items::NETHERITE_LEGGINGS());
 		$result->register("netherite_pickaxe", fn() => Items::NETHERITE_PICKAXE());
 		$result->register("netherite_scrap", fn() => Items::NETHERITE_SCRAP());
+		$result->register("netherite_spear", fn() => Items::NETHERITE_SPEAR());
 		$result->register("netherite_shovel", fn() => Items::NETHERITE_SHOVEL());
 		$result->register("netherite_sword", fn() => Items::NETHERITE_SWORD());
 		$result->register("netherstar", fn() => Items::NETHER_STAR());
@@ -1625,6 +1630,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("stone_hoe", fn() => Items::STONE_HOE());
 		$result->register("stone_pickaxe", fn() => Items::STONE_PICKAXE());
 		$result->register("stone_shovel", fn() => Items::STONE_SHOVEL());
+		$result->register("stone_spear", fn() => Items::STONE_SPEAR());
 		$result->register("stone_sword", fn() => Items::STONE_SWORD());
 		$result->register("string", fn() => Items::STRING());
 		$result->register("sugar", fn() => Items::SUGAR());
@@ -1650,6 +1656,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("wooden_hoe", fn() => Items::WOODEN_HOE());
 		$result->register("wooden_pickaxe", fn() => Items::WOODEN_PICKAXE());
 		$result->register("wooden_shovel", fn() => Items::WOODEN_SHOVEL());
+		$result->register("wooden_spear", fn() => Items::WOODEN_SPEAR());
 		$result->register("wooden_sword", fn() => Items::WOODEN_SWORD());
 		$result->register("writable_book", fn() => Items::WRITABLE_BOOK());
 		$result->register("written_book", fn() => Items::WRITTEN_BOOK());

--- a/src/item/VanillaItems.php
+++ b/src/item/VanillaItems.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
 
 declare(strict_types=1);
@@ -146,6 +146,7 @@ use function strtolower;
  * @method static Armor COPPER_LEGGINGS()
  * @method static Item COPPER_NUGGET()
  * @method static Pickaxe COPPER_PICKAXE()
+ * @method static Spear COPPER_SPEAR()
  * @method static Shovel COPPER_SHOVEL()
  * @method static Sword COPPER_SWORD()
  * @method static CoralFan CORAL_FAN()
@@ -162,6 +163,7 @@ use function strtolower;
  * @method static Hoe DIAMOND_HOE()
  * @method static Armor DIAMOND_LEGGINGS()
  * @method static Pickaxe DIAMOND_PICKAXE()
+ * @method static Spear DIAMOND_SPEAR()
  * @method static Shovel DIAMOND_SHOVEL()
  * @method static Sword DIAMOND_SWORD()
  * @method static Item DISC_FRAGMENT_5()
@@ -203,6 +205,7 @@ use function strtolower;
  * @method static Hoe GOLDEN_HOE()
  * @method static Armor GOLDEN_LEGGINGS()
  * @method static Pickaxe GOLDEN_PICKAXE()
+ * @method static Spear GOLDEN_SPEAR()
  * @method static Shovel GOLDEN_SHOVEL()
  * @method static Sword GOLDEN_SWORD()
  * @method static Item GOLD_INGOT()
@@ -223,6 +226,7 @@ use function strtolower;
  * @method static Armor IRON_LEGGINGS()
  * @method static Item IRON_NUGGET()
  * @method static Pickaxe IRON_PICKAXE()
+ * @method static Spear IRON_SPEAR()
  * @method static Shovel IRON_SHOVEL()
  * @method static Sword IRON_SWORD()
  * @method static Boat JUNGLE_BOAT()
@@ -256,6 +260,7 @@ use function strtolower;
  * @method static Item NETHERITE_INGOT()
  * @method static Armor NETHERITE_LEGGINGS()
  * @method static Pickaxe NETHERITE_PICKAXE()
+ * @method static Spear NETHERITE_SPEAR()
  * @method static Item NETHERITE_SCRAP()
  * @method static Shovel NETHERITE_SHOVEL()
  * @method static Sword NETHERITE_SWORD()
@@ -343,6 +348,7 @@ use function strtolower;
  * @method static Axe STONE_AXE()
  * @method static Hoe STONE_HOE()
  * @method static Pickaxe STONE_PICKAXE()
+ * @method static Spear STONE_SPEAR()
  * @method static Shovel STONE_SHOVEL()
  * @method static Sword STONE_SWORD()
  * @method static StringItem STRING()
@@ -367,6 +373,7 @@ use function strtolower;
  * @method static Axe WOODEN_AXE()
  * @method static Hoe WOODEN_HOE()
  * @method static Pickaxe WOODEN_PICKAXE()
+ * @method static Spear WOODEN_SPEAR()
  * @method static Shovel WOODEN_SHOVEL()
  * @method static Sword WOODEN_SWORD()
  * @method static WritableBook WRITABLE_BOOK()
@@ -703,6 +710,7 @@ final class VanillaItems{
 			self::register($idPrefix . "_pickaxe", fn(IID $id) => new Pickaxe($id, $namePrefix . " Pickaxe", $tier, [EnchantmentTags::PICKAXE]));
 			self::register($idPrefix . "_shovel", fn(IID $id) => new Shovel($id, $namePrefix . " Shovel", $tier, [EnchantmentTags::SHOVEL]));
 			self::register($idPrefix . "_sword", fn(IID $id) => new Sword($id, $namePrefix . " Sword", $tier, [EnchantmentTags::SWORD]));
+			self::register($idPrefix . "_spear", fn(IID $id) => new Spear($id, $namePrefix . " Spear", $tier, [EnchantmentTags::SPEAR]));
 		}
 	}
 

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -373,6 +373,7 @@ final class VanillaItemsInputs extends RegistrySource{
 			self::register($idPrefix . "_pickaxe", fn(IID $id) => new Pickaxe($id, $namePrefix . " Pickaxe", $tier, [EnchantmentTags::PICKAXE]));
 			self::register($idPrefix . "_shovel", fn(IID $id) => new Shovel($id, $namePrefix . " Shovel", $tier, [EnchantmentTags::SHOVEL]));
 			self::register($idPrefix . "_sword", fn(IID $id) => new Sword($id, $namePrefix . " Sword", $tier, [EnchantmentTags::SWORD]));
+			self::register($idPrefix . "_spear", fn(IID $id) => new Spear($id, $namePrefix . " Spear", $tier, [EnchantmentTags::SPEAR]));
 		}
 	}
 

--- a/src/item/enchantment/AvailableEnchantmentRegistry.php
+++ b/src/item/enchantment/AvailableEnchantmentRegistry.php
@@ -59,9 +59,13 @@ final class AvailableEnchantmentRegistry{
 		$this->register(Enchantments::RESPIRATION(), [Tags::HELMET], []);
 		$this->register(Enchantments::AQUA_AFFINITY(), [Tags::HELMET], []);
 		$this->register(Enchantments::FROST_WALKER(), [/* no primary items */], [Tags::BOOTS]);
-		$this->register(Enchantments::SHARPNESS(), [Tags::SWORD, Tags::AXE], []);
-		$this->register(Enchantments::KNOCKBACK(), [Tags::SWORD], []);
-		$this->register(Enchantments::FIRE_ASPECT(), [Tags::SWORD], []);
+		$this->register(Enchantments::SHARPNESS(), [Tags::SWORD, Tags::SPEAR, Tags::AXE], []);
+		$this->register(Enchantments::SMITE(), [Tags::SWORD, Tags::SPEAR], []);
+		$this->register(Enchantments::BANE_OF_ARTHROPODS(), [Tags::SWORD, Tags::SPEAR], []);
+		$this->register(Enchantments::KNOCKBACK(), [Tags::SWORD, Tags::SPEAR], []);
+		$this->register(Enchantments::FIRE_ASPECT(), [Tags::SWORD, Tags::SPEAR], []);
+		$this->register(Enchantments::LOOTING(), [Tags::SWORD, Tags::SPEAR], []);
+		$this->register(Enchantments::LUNGE(), [Tags::SPEAR], []);
 		$this->register(Enchantments::EFFICIENCY(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);
 		$this->register(Enchantments::FORTUNE(), [Tags::BLOCK_TOOLS], []);
 		$this->register(Enchantments::SILK_TOUCH(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);

--- a/src/item/enchantment/BaneOfArthropodsEnchantment.php
+++ b/src/item/enchantment/BaneOfArthropodsEnchantment.php
@@ -1,0 +1,49 @@
+<?php
+
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item\enchantment;
+
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+use pocketmine\entity\effect\EffectInstance;
+use pocketmine\entity\effect\VanillaEffects;
+use function mt_rand;
+
+class BaneOfArthropodsEnchantment extends MeleeWeaponEnchantment{
+
+	public function isApplicableTo(Entity $victim) : bool{
+		return $victim instanceof Living && $victim->isArthropod();
+	}
+
+	public function getDamageBonus(int $enchantmentLevel) : float{
+		return $enchantmentLevel * 2.5;
+	}
+
+	public function onPostAttack(Entity $attacker, Entity $victim, int $enchantmentLevel) : void{
+		if($victim instanceof Living && $victim->isArthropod()){
+			$duration = 20 + mt_rand(0, 10 * $enchantmentLevel - 1);
+			$victim->getEffects()->add(new EffectInstance(VanillaEffects::SLOWNESS(), $duration, 3));
+		}
+	}
+}

--- a/src/item/enchantment/IncompatibleEnchantmentGroups.php
+++ b/src/item/enchantment/IncompatibleEnchantmentGroups.php
@@ -31,4 +31,5 @@ final class IncompatibleEnchantmentGroups{
 	public const PROTECTION = "protection";
 	public const BOW_INFINITE = "bow_infinite";
 	public const BLOCK_DROPS = "block_drops";
+	public const WEAPON_DAMAGE = "weapon_damage";
 }

--- a/src/item/enchantment/IncompatibleEnchantmentRegistry.php
+++ b/src/item/enchantment/IncompatibleEnchantmentRegistry.php
@@ -47,6 +47,7 @@ final class IncompatibleEnchantmentRegistry{
 		$this->register(Groups::PROTECTION, [Enchantments::PROTECTION(), Enchantments::FIRE_PROTECTION(), Enchantments::BLAST_PROTECTION(), Enchantments::PROJECTILE_PROTECTION()]);
 		$this->register(Groups::BOW_INFINITE, [Enchantments::INFINITY(), Enchantments::MENDING()]);
 		$this->register(Groups::BLOCK_DROPS, [Enchantments::FORTUNE(), Enchantments::SILK_TOUCH()]);
+		$this->register(Groups::WEAPON_DAMAGE, [Enchantments::SHARPNESS(), Enchantments::SMITE(), Enchantments::BANE_OF_ARTHROPODS()]);
 	}
 
 	/**

--- a/src/item/enchantment/ItemEnchantmentTagRegistry.php
+++ b/src/item/enchantment/ItemEnchantmentTagRegistry.php
@@ -52,6 +52,7 @@ final class ItemEnchantmentTagRegistry{
 		$this->register(Tags::ARMOR, [Tags::HELMET, Tags::CHESTPLATE, Tags::LEGGINGS, Tags::BOOTS]);
 		$this->register(Tags::SHIELD);
 		$this->register(Tags::SWORD);
+		$this->register(Tags::SPEAR);
 		$this->register(Tags::TRIDENT);
 		$this->register(Tags::BOW);
 		$this->register(Tags::CROSSBOW);
@@ -66,6 +67,7 @@ final class ItemEnchantmentTagRegistry{
 		$this->register(Tags::BRUSH);
 		$this->register(Tags::WEAPONS, [
 			Tags::SWORD,
+			Tags::SPEAR,
 			Tags::TRIDENT,
 			Tags::BOW,
 			Tags::CROSSBOW,

--- a/src/item/enchantment/ItemEnchantmentTags.php
+++ b/src/item/enchantment/ItemEnchantmentTags.php
@@ -37,6 +37,7 @@ final class ItemEnchantmentTags{
 	public const BOOTS = "boots";
 	public const SHIELD = "shield";
 	public const SWORD = "sword";
+	public const SPEAR = "spear";
 	public const TRIDENT = "trident";
 	public const BOW = "bow";
 	public const CROSSBOW = "crossbow";

--- a/src/item/enchantment/SmiteEnchantment.php
+++ b/src/item/enchantment/SmiteEnchantment.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item\enchantment;
+
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+
+class SmiteEnchantment extends MeleeWeaponEnchantment{
+
+	public function isApplicableTo(Entity $victim) : bool{
+		return $victim instanceof Living && $victim->isUndead();
+	}
+
+	public function getDamageBonus(int $enchantmentLevel) : float{
+		return $enchantmentLevel * 2.5;
+	}
+}

--- a/src/item/enchantment/StringToEnchantmentParser.php
+++ b/src/item/enchantment/StringToEnchantmentParser.php
@@ -55,6 +55,10 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result->register("respiration", fn() => VanillaEnchantments::RESPIRATION());
 		$result->register("aqua_affinity", fn() => VanillaEnchantments::AQUA_AFFINITY());
 		$result->register("sharpness", fn() => VanillaEnchantments::SHARPNESS());
+		$result->register("smite", fn() => VanillaEnchantments::SMITE());
+		$result->register("bane_of_arthropods", fn() => VanillaEnchantments::BANE_OF_ARTHROPODS());
+		$result->register("looting", fn() => VanillaEnchantments::LOOTING());
+		$result->register("lunge", fn() => VanillaEnchantments::LUNGE());
 		$result->register("silk_touch", fn() => VanillaEnchantments::SILK_TOUCH());
 		$result->register("swift_sneak", fn() => VanillaEnchantments::SWIFT_SNEAK());
 		$result->register("thorns", fn() => VanillaEnchantments::THORNS());

--- a/src/item/enchantment/VanillaEnchantments.php
+++ b/src/item/enchantment/VanillaEnchantments.php
@@ -34,6 +34,7 @@ use pocketmine\utils\RegistryTrait;
  * @generate-registry-docblock
  *
  * @method static Enchantment AQUA_AFFINITY()
+ * @method static BaneOfArthropodsEnchantment BANE_OF_ARTHROPODS()
  * @method static ProtectionEnchantment BLAST_PROTECTION()
  * @method static Enchantment EFFICIENCY()
  * @method static ProtectionEnchantment FEATHER_FALLING()
@@ -44,6 +45,8 @@ use pocketmine\utils\RegistryTrait;
  * @method static Enchantment FROST_WALKER()
  * @method static Enchantment INFINITY()
  * @method static KnockbackEnchantment KNOCKBACK()
+ * @method static Enchantment LUNGE()
+ * @method static Enchantment LOOTING()
  * @method static Enchantment MENDING()
  * @method static Enchantment POWER()
  * @method static ProtectionEnchantment PROJECTILE_PROTECTION()
@@ -52,6 +55,7 @@ use pocketmine\utils\RegistryTrait;
  * @method static Enchantment RESPIRATION()
  * @method static SharpnessEnchantment SHARPNESS()
  * @method static Enchantment SILK_TOUCH()
+ * @method static SmiteEnchantment SMITE()
  * @method static Enchantment SWIFT_SNEAK()
  * @method static Enchantment THORNS()
  * @method static Enchantment UNBREAKING()
@@ -175,6 +179,24 @@ final class VanillaEnchantments{
 			fn(int $level) : int => 11 * ($level - 1) + 1,
 			20
 		));
+		self::register("SMITE", new SmiteEnchantment(
+			KnownTranslationFactory::enchantment_damage_undead(),
+			Rarity::UNCOMMON,
+			0,
+			0,
+			5,
+			fn(int $level) : int => 8 * ($level - 1) + 5,
+			20
+		));
+		self::register("BANE_OF_ARTHROPODS", new BaneOfArthropodsEnchantment(
+			KnownTranslationFactory::enchantment_damage_arthropods(),
+			Rarity::UNCOMMON,
+			0,
+			0,
+			5,
+			fn(int $level) : int => 8 * ($level - 1) + 5,
+			20
+		));
 		self::register("KNOCKBACK", new KnockbackEnchantment(
 			KnownTranslationFactory::enchantment_knockback(),
 			Rarity::UNCOMMON,
@@ -193,7 +215,24 @@ final class VanillaEnchantments{
 			fn(int $level) : int => 20 * ($level - 1) + 10,
 			50
 		));
-		//TODO: smite, bane of arthropods, looting (these don't make sense now because their applicable mobs don't exist yet)
+		self::register("LOOTING", new Enchantment(
+			KnownTranslationFactory::enchantment_lootBonus(),
+			Rarity::RARE,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 9 * ($level - 1) + 15,
+			50
+		));
+		self::register("LUNGE", new Enchantment(
+			"Lunge",
+			Rarity::UNCOMMON,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 10 * ($level - 1) + 12,
+			25
+		));
 
 		self::register("EFFICIENCY", new Enchantment(
 			KnownTranslationFactory::enchantment_digging(),

--- a/src/item/enchantment/VanillaEnchantmentsInputs.php
+++ b/src/item/enchantment/VanillaEnchantmentsInputs.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
 
 declare(strict_types=1);
@@ -155,6 +155,24 @@ final class VanillaEnchantmentsInputs extends RegistrySource{
 			fn(int $level) : int => 11 * ($level - 1) + 1,
 			20
 		));
+		self::register("SMITE", new SmiteEnchantment(
+			KnownTranslationFactory::enchantment_damage_undead(),
+			Rarity::UNCOMMON,
+			0,
+			0,
+			5,
+			fn(int $level) : int => 8 * ($level - 1) + 5,
+			20
+		));
+		self::register("BANE_OF_ARTHROPODS", new BaneOfArthropodsEnchantment(
+			KnownTranslationFactory::enchantment_damage_arthropods(),
+			Rarity::UNCOMMON,
+			0,
+			0,
+			5,
+			fn(int $level) : int => 8 * ($level - 1) + 5,
+			20
+		));
 		self::register("KNOCKBACK", new KnockbackEnchantment(
 			KnownTranslationFactory::enchantment_knockback(),
 			Rarity::UNCOMMON,
@@ -173,7 +191,24 @@ final class VanillaEnchantmentsInputs extends RegistrySource{
 			fn(int $level) : int => 20 * ($level - 1) + 10,
 			50
 		));
-		//TODO: smite, bane of arthropods, looting (these don't make sense now because their applicable mobs don't exist yet)
+		self::register("LOOTING", new Enchantment(
+			KnownTranslationFactory::enchantment_lootBonus(),
+			Rarity::RARE,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 9 * ($level - 1) + 15,
+			50
+		));
+		self::register("LUNGE", new Enchantment(
+			"Lunge",
+			Rarity::UNCOMMON,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 10 * ($level - 1) + 12,
+			25
+		));
 
 		self::register("EFFICIENCY", new Enchantment(
 			KnownTranslationFactory::enchantment_digging(),

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
 
 declare(strict_types=1);
@@ -31,6 +31,7 @@ use pocketmine\block\tile\Beacon as BeaconTile;
 use pocketmine\block\tile\Sign;
 use pocketmine\block\utils\SignText;
 use pocketmine\entity\Attribute;
+use pocketmine\entity\Entity;
 use pocketmine\entity\InvalidSkinException;
 use pocketmine\event\player\PlayerEditBookEvent;
 use pocketmine\inventory\transaction\action\DropItemAction;
@@ -39,6 +40,7 @@ use pocketmine\inventory\transaction\TransactionBuilder;
 use pocketmine\inventory\transaction\TransactionCancelledException;
 use pocketmine\inventory\transaction\TransactionValidationException;
 use pocketmine\item\VanillaItems;
+use pocketmine\item\Spear;
 use pocketmine\item\WritableBook;
 use pocketmine\item\WritableBookPage;
 use pocketmine\item\WrittenBook;
@@ -135,6 +137,7 @@ use const JSON_THROW_ON_ERROR;
 class InGamePacketHandler extends PacketHandler{
 	private const MAX_FORM_RESPONSE_SIZE = 10 * 1024; //10 KiB should be more than enough
 	private const MAX_FORM_RESPONSE_DEPTH = 2; //modal/simple will be 1, custom forms 2 - they will never contain anything other than string|int|float|bool|null
+	private const SPEAR_TRACE_FALLBACK_MIN_DOT = 0.55;
 
 	//TODO: The client-side per-page character limit is inconsistent for non-ASCII text,
 	//allowing input beyond 256 chars. Use a slightly higher bounded soft limit to
@@ -623,9 +626,114 @@ class InGamePacketHandler extends PacketHandler{
 				}
 				$this->player->useHeldItem();
 				return true;
+			case UseItemTransactionData::ACTION_USE_AS_ATTACK:
+				$heldItem = $this->player->getInventory()->getItemInHand();
+				if($heldItem instanceof Spear){
+					return $this->executeSpearJab();
+				}
+				return $this->player->useHeldItem();
 		}
 
 		return false;
+	}
+
+	private function executeSpearJab(?Entity $prioritizedTarget = null) : bool{
+		$heldItem = $this->player->getInventory()->getItemInHand();
+		if(!($heldItem instanceof Spear)){
+			return false;
+		}
+
+		if($this->player->hasItemCooldown($heldItem)){
+			$this->player->missSwing();
+			return true;
+		}
+
+		$lungeActivated = $heldItem->activateLunge($this->player);
+
+		$targets = $this->findSpearJabTargets($heldItem, $prioritizedTarget);
+		$this->player->resetItemCooldown($heldItem, $heldItem->getJabCooldownTicks());
+
+		if(count($targets) === 0){
+			if($lungeActivated){
+				$currentHeldItem = $this->player->getInventory()->getItemInHand();
+				if($currentHeldItem instanceof Spear){
+					$currentHeldItem->applyDamage(1);
+					$this->player->getInventory()->setItemInHand($currentHeldItem);
+				}
+			}
+			$this->player->missSwing();
+			return true;
+		}
+
+		$damaged = false;
+		foreach($targets as $target){
+			$damaged = $this->player->attackEntity($target) || $damaged;
+		}
+
+		if($lungeActivated){
+			$currentHeldItem = $this->player->getInventory()->getItemInHand();
+			if($currentHeldItem instanceof Spear){
+				$currentHeldItem->applyDamage(1);
+				$this->player->getInventory()->setItemInHand($currentHeldItem);
+			}
+		}
+
+		if(!$damaged){
+			$this->player->missSwing();
+		}
+
+		return true;
+	}
+
+	/**
+	 * @return Entity[]
+	 */
+	private function findSpearJabTargets(Spear $spear, ?Entity $prioritizedTarget = null) : array{
+		$eyePos = $this->player->getEyePos();
+		$direction = $this->player->getDirectionVector()->normalize();
+		$traceEnd = $eyePos->addVector($direction->multiply($spear->getJabMaxDistance()));
+		$searchRadius = $spear->getJabMaxDistance() + $spear->getJabHitboxMargin();
+		$searchBox = $this->player->getBoundingBox()->expandedCopy($searchRadius, $searchRadius, $searchRadius);
+
+		$candidates = [];
+		foreach($this->player->getWorld()->getNearbyEntities($searchBox, $this->player) as $entity){
+			if(!$entity->isAlive() || $entity->isFlaggedForDespawn()){
+				continue;
+			}
+
+			$targetPos = $entity->getPosition()->add(0, $entity->size->getHeight() / 2, 0);
+			$distance = $eyePos->distance($targetPos);
+			if($distance > $spear->getJabMaxDistance() || $distance < $spear->getJabMinDistance()){
+				continue;
+			}
+
+			$expandedHitBox = $entity->getBoundingBox()->expandedCopy($spear->getJabHitboxMargin(), $spear->getJabHitboxMargin(), $spear->getJabHitboxMargin());
+			if($expandedHitBox->calculateIntercept($eyePos, $traceEnd) === null){
+				if($prioritizedTarget !== $entity){
+					continue;
+				}
+
+				$toEntity = $targetPos->subtractVector($eyePos)->normalize();
+				if($direction->dot($toEntity) < self::SPEAR_TRACE_FALLBACK_MIN_DOT){
+					continue;
+				}
+			}
+
+			$candidates[] = [
+				"entity" => $entity,
+				"distance" => $distance,
+				"priority" => $prioritizedTarget === $entity ? -1 : 0,
+			];
+		}
+
+		usort($candidates, static fn(array $a, array $b) : int => ($a["priority"] <=> $b["priority"]) ?: ($a["distance"] <=> $b["distance"]));
+
+		$targets = [];
+		foreach($candidates as $candidate){
+			$targets[] = $candidate["entity"];
+		}
+
+		return $targets;
 	}
 
 	/**
@@ -669,9 +777,21 @@ class InGamePacketHandler extends PacketHandler{
 
 		switch($data->getActionType()){
 			case UseItemOnEntityTransactionData::ACTION_INTERACT:
+				$heldItem = $this->player->getInventory()->getItemInHand();
+				if($heldItem instanceof Spear){
+					if(!$this->player->isUsingItem()){
+						$this->player->useHeldItem();
+					}
+					return true;
+				}
 				$this->player->interactEntity($target, $data->getClickPosition());
 				return true;
 			case UseItemOnEntityTransactionData::ACTION_ATTACK:
+				$heldItem = $this->player->getInventory()->getItemInHand();
+				if($heldItem instanceof Spear){
+					return $this->executeSpearJab($target);
+				}
+
 				$this->player->attackEntity($target);
 				return true;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -105,6 +105,7 @@ use pocketmine\item\enchantment\MeleeWeaponEnchantment;
 use pocketmine\item\Item;
 use pocketmine\item\ItemUseResult;
 use pocketmine\item\Releasable;
+use pocketmine\item\Spear;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\Language;
 use pocketmine\lang\Translatable;
@@ -1661,8 +1662,12 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 				$this->blockBreakHandler = null;
 			}
 
-			if($this->isUsingItem() && $this->getItemUseDuration() % 4 === 0 && ($item = $this->inventory->getItemInHand()) instanceof ConsumableItem){
-				$this->broadcastAnimation(new ConsumingItemAnimation($this, $item));
+			if($this->isUsingItem()){
+				$item = $this->inventory->getItemInHand();
+				if($this->getItemUseDuration() % 4 === 0 && $item instanceof ConsumableItem){
+					$this->broadcastAnimation(new ConsumingItemAnimation($this, $item));
+				}
+				$item->whileUsing($this);
 			}
 		}
 
@@ -1817,7 +1822,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$oldItem = clone $item;
 
 		$ev = new PlayerItemUseEvent($this, $item, $directionVector);
-		if($this->hasItemCooldown($item) || $this->isSpectator()){
+		if(($this->hasItemCooldown($item) && !($item instanceof Spear)) || $this->isSpectator()){
 			$ev->cancel();
 		}
 
@@ -2138,7 +2143,18 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$oldItem = clone $heldItem;
 
 		$ev = new EntityDamageByEntityEvent($this, $entity, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
-		if(!$this->canInteract($entity->getLocation(), self::MAX_REACH_DISTANCE_ENTITY_INTERACTION)){
+		if($heldItem instanceof Spear){
+			$targetPos = $entity->getPosition()->add(0, $entity->size->getHeight() / 2, 0);
+			if(!$this->canInteract($targetPos, $heldItem->getJabMaxDistance())){
+				$this->logger->debug("Cancelled spear attack of entity " . $entity->getId() . " due to out-of-range interaction");
+				$ev->cancel();
+			}elseif($this->getEyePos()->distance($targetPos) < $heldItem->getJabMinDistance()){
+				$this->logger->debug("Cancelled spear attack of entity " . $entity->getId() . " due to minimum jab distance");
+				$ev->cancel();
+			}elseif($this->isSpectator() || ($entity instanceof Player && !$this->server->getConfigGroup()->getConfigBool(ServerProperties::PVP))){
+				$ev->cancel();
+			}
+		}elseif(!$this->canInteract($entity->getLocation(), self::MAX_REACH_DISTANCE_ENTITY_INTERACTION)){
 			$this->logger->debug("Cancelled attack of entity " . $entity->getId() . " due to not currently being interactable");
 			$ev->cancel();
 		}elseif($this->isSpectator() || ($entity instanceof Player && !$this->server->getConfigGroup()->getConfigBool(ServerProperties::PVP))){
@@ -2157,7 +2173,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 		$ev->setModifier($meleeEnchantmentDamage, EntityDamageEvent::MODIFIER_WEAPON_ENCHANTMENTS);
 
-		if(!$this->isSprinting() && !$this->isFlying() && $this->fallDistance > 0 && !$this->effectManager->has(VanillaEffects::BLINDNESS()) && !$this->isUnderwater()){
+		if(!($heldItem instanceof Spear) && !$this->isSprinting() && !$this->isFlying() && $this->fallDistance > 0 && !$this->effectManager->has(VanillaEffects::BLINDNESS()) && !$this->isUnderwater()){
 			$ev->setModifier($ev->getFinalDamage() / 2, EntityDamageEvent::MODIFIER_CRITICAL);
 		}
 
@@ -2169,7 +2185,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			$this->getWorld()->addSound($soundPos, new EntityAttackNoDamageSound());
 			return false;
 		}
-		$this->getWorld()->addSound($soundPos, new EntityAttackSound());
+		$this->getWorld()->addSound($soundPos, $heldItem instanceof Spear ? $heldItem->getAttackHitSound() : new EntityAttackSound());
 
 		if($ev->getModifier(EntityDamageEvent::MODIFIER_CRITICAL) > 0 && $entity instanceof Living){
 			$entity->broadcastAnimation(new CriticalHitAnimation($entity));

--- a/src/world/sound/SimpleLevelSound.php
+++ b/src/world/sound/SimpleLevelSound.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+
+final class SimpleLevelSound implements Sound{
+
+	public function __construct(
+		private int $soundId
+	){}
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound($this->soundId, $pos, false)];
+	}
+}


### PR DESCRIPTION
# 5.41.3
Released 5th April 2026.

This release focuses on spear combat and enchantment support.

## Spear enchantments
- Spears can now receive and use weapon enchantments in normal workflows (enchanting/anvil/command parsing).
- Added and wired support for spear usage with:
  - Sharpness
  - Smite
  - Bane of Arthropods
  - Looting
  - Knockback
  - Fire Aspect
  - Lunge
  - Unbreaking
  - Mending
  - Curse of Vanishing
- Added incompatibility wiring for damage-family weapon enchantments (Sharpness/Smite/Bane) so conflict rules are respected.
- Updated enchant parser and Bedrock ID mappings for newly wired enchantments.

## Lunge on spear jab
- Lunge now activates on spear jab and propels the player forward.
- Lunge consumption scales by enchant level:
  - Level I: consumes 1 point
  - Level II: consumes 2 points
  - Level III: consumes 3 points
- Consumption order follows vanilla-like behavior:
  - Saturation is consumed first.
  - Hunger is consumed after saturation.
- Lunge additionally consumes 1 spear durability when activated.
- Lunge is blocked when conditions are invalid:
  - Player has less than 6 hunger points.
  - Player is underwater/swimming.
  - Player is gliding.
  - Player is in water.

## Drops and combat integration
- Connected Looting into relevant drop paths so spear kills benefit from looting level.
- Applied target-type damage hooks for Smite (undead) and Bane of Arthropods (arthropods), including Bane slow effect behavior.

## Notes
- Spear jab + immediate follow-up charge now benefits from Lunge velocity, improving connect potential at medium distance.
