### PR TITLE
Add new entities, Copper Chest, and baby mechanics

### DIFF
--- a/changelogs/5.41.7.md
+++ b/changelogs/5.41.7.md
@@ -1,0 +1,37 @@
+# 5.41.11
+Released 12th April 2026.
+
+This release completes Happy Ghast baby gameplay flow, adds full Sniffer Egg hatching support, integrates Chicken Spawn Egg gameplay, and fixes multiple interaction, blockstate, and creative inventory issues.
+
+## Added
+- Added baby-state support for `HappyGhast` with NBT persistence and network metadata syncing.
+- Added baby growth flow for `HappyGhast`:
+  - Natural growth over time.
+  - Accelerated growth by feeding snowballs.
+- Added interaction support so using a spawn egg on a `HappyGhast` spawns a baby `HappyGhast`.
+- Added `/give` and parser alias support for `dried_ghast` block item name.
+- Added `SnifferEgg` block implementation with staged `cracked_state` progression and delayed hatch behavior.
+- Added full `sniffer_egg` integration in block registries, runtime type IDs, Bedrock blockstate mappings, and parser aliases.
+- Added spawn-egg interaction support on `Sniffer`, so using a spawn egg on an existing sniffer spawns a baby sniffer.
+- Added `Chicken` entity implementation and registered it in entity factory save/load mappings.
+- Added `chicken_spawn_egg` item registration in `VanillaItems` and `VanillaItemsInputs`.
+- Added serializer/deserializer mapping for `minecraft:chicken_spawn_egg`.
+- Added string parser alias support for `chicken_spawn_egg`.
+
+## Changed
+- `DriedGhast` now tracks horizontal facing (`minecraft:cardinal_direction`) as part of its block state and sets facing from player placement direction.
+- Rehydrating `DriedGhast` now spawns a baby `HappyGhast` instead of an adult.
+- Rebalanced `DriedGhast` hydration pacing by increasing hydration update interval to a delayed cadence, so transformation timing matches expected wait behavior.
+- `Sniffer` now persists baby state and growth age in NBT and naturally grows into adult over time.
+- Updated Nature creative data so egg-like blocks (`dragon_egg`, `turtle_egg`, `sniffer_egg`, `dried_ghast`, `frog_spawn`) are displayed under a visible grouped section instead of an ungrouped slot.
+
+## Fixed
+- Fixed `DriedGhast` blockstate deserialization mismatch caused by missing `cardinal_direction` handling, which could prevent the item from appearing or working correctly in creative inventory flows.
+- Fixed a double-action interaction where right-clicking a baby `HappyGhast` with a snowball could both throw the snowball and apply growth in the same input flow.
+- Feeding now suppresses immediate click-air handling for the same interaction tick and applies a short cooldown to prevent unintended projectile launch.
+- Fixed a remaining packet-order edge case where right-clicking a baby `HappyGhast` with a snowball could still both throw the snowball and apply growth.
+- Snowball click-air suppression now uses a short post-interact guard window and more tolerant aimed-entity interception for baby `HappyGhast` feed interactions.
+- Fixed missing gameplay pipeline for place-and-wait Sniffer egg hatching.
+
+## Changed
+- Bumped BASE_VERSION to 5.41.11.

--- a/changelogs/5.41.7.md
+++ b/changelogs/5.41.7.md
@@ -1,4 +1,4 @@
-# 5.41.11
+# 5.41.7
 Released 12th April 2026.
 
 This release completes Happy Ghast baby gameplay flow, adds full Sniffer Egg hatching support, integrates Chicken Spawn Egg gameplay, and fixes multiple interaction, blockstate, and creative inventory issues.

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,7 +31,7 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "beeltymine-mp";
-	public const BASE_VERSION = "5.41.6";
+	public const BASE_VERSION = "5.41.7";
 	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 	public const GITHUB_URL = "https://github.com/BeeltyMine/BeeltyMine-MP";

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -890,8 +890,9 @@ final class BlockTypeIds{
 	public const WAXED_OXIDIZED_COPPER_GOLEM_STATUE = 10860;
 	public const COPPER_CHEST = 10861;
 	public const DRIED_GHAST = 10862;
+	public const SNIFFER_EGG = 10863;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10863;
+	public const FIRST_UNUSED_BLOCK_ID = 10864;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -888,8 +888,10 @@ final class BlockTypeIds{
 	public const WAXED_EXPOSED_COPPER_GOLEM_STATUE = 10858;
 	public const WAXED_WEATHERED_COPPER_GOLEM_STATUE = 10859;
 	public const WAXED_OXIDIZED_COPPER_GOLEM_STATUE = 10860;
+	public const COPPER_CHEST = 10861;
+	public const DRIED_GHAST = 10862;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10861;
+	public const FIRST_UNUSED_BLOCK_ID = 10863;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/CopperChest.php
+++ b/src/block/CopperChest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\CopperMaterial;
+use pocketmine\block\utils\CopperTrait;
+use pocketmine\item\Item;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+
+class CopperChest extends Chest implements CopperMaterial{
+	use CopperTrait{
+		onInteract as onInteractCopper;
+	}
+
+	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
+		if(($player === null || $player->isSneaking()) && $this->onInteractCopper($item, $face, $clickVector, $player, $returnedItems)){
+			return true;
+		}
+
+		return parent::onInteract($item, $face, $clickVector, $player, $returnedItems);
+	}
+
+	public function getFuelTime() : int{
+		return 0;
+	}
+}

--- a/src/block/DriedGhast.php
+++ b/src/block/DriedGhast.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\SupportType;
+use pocketmine\data\runtime\RuntimeDataDescriber;
+use pocketmine\entity\HappyGhast;
+use pocketmine\entity\Location;
+use pocketmine\item\Item;
+use pocketmine\math\AxisAlignedBB;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\BlockTransaction;
+use pocketmine\world\sound\GhastSound;
+use function mt_rand;
+
+class DriedGhast extends Transparent{
+	private const UPDATE_INTERVAL_TICKS = 40;
+	private const MAX_REHYDRATION_LEVEL = 3;
+
+	private int $rehydrationLevel = 0;
+
+	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
+		$w->boundedIntAuto(0, self::MAX_REHYDRATION_LEVEL, $this->rehydrationLevel);
+	}
+
+	public function getRehydrationLevel() : int{
+		return $this->rehydrationLevel;
+	}
+
+	/** @return $this */
+	public function setRehydrationLevel(int $rehydrationLevel) : self{
+		if($rehydrationLevel < 0 || $rehydrationLevel > self::MAX_REHYDRATION_LEVEL){
+			throw new \InvalidArgumentException("Rehydration level must be in range 0..." . self::MAX_REHYDRATION_LEVEL);
+		}
+
+		$this->rehydrationLevel = $rehydrationLevel;
+		return $this;
+	}
+
+	protected function recalculateCollisionBoxes() : array{
+		return [
+			AxisAlignedBB::one()
+				->contract(0.1875, 0, 0.1875)
+				->trim(Facing::UP, 0.125)
+		];
+	}
+
+	public function getSupportType(int $facing) : SupportType{
+		return SupportType::NONE;
+	}
+
+	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
+		$this->rehydrationLevel = 0;
+		$placed = parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		if($placed){
+			$this->scheduleHydrationTick();
+		}
+
+		return $placed;
+	}
+
+	public function onNearbyBlockChange() : void{
+		$this->scheduleHydrationTick();
+	}
+
+	public function onScheduledUpdate() : void{
+		$world = $this->position->getWorld();
+		$touchingWater = $this->isTouchingWater();
+		$nextLevel = $this->rehydrationLevel;
+
+		if($touchingWater){
+			if($nextLevel < self::MAX_REHYDRATION_LEVEL){
+				++$nextLevel;
+			}
+		}elseif($nextLevel > 0){
+			--$nextLevel;
+		}
+
+		if($nextLevel !== $this->rehydrationLevel){
+			$world->setBlock($this->position, $this->setRehydrationLevel($nextLevel));
+		}
+
+		if($touchingWater && $nextLevel >= self::MAX_REHYDRATION_LEVEL){
+			$world->setBlock($this->position, VanillaBlocks::AIR());
+			$happyGhast = new HappyGhast(Location::fromObject(
+				$this->position->add(0.5, 1.0, 0.5),
+				$world,
+				mt_rand(0, 359),
+				0
+			));
+			$happyGhast->spawnToAll();
+			$world->addSound($this->position, new GhastSound());
+			return;
+		}
+
+		if($touchingWater || $nextLevel > 0){
+			$this->scheduleHydrationTick();
+		}
+	}
+
+	private function scheduleHydrationTick() : void{
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, self::UPDATE_INTERVAL_TICKS);
+	}
+
+	private function isTouchingWater() : bool{
+		$world = $this->position->getWorld();
+		foreach(Facing::ALL as $face){
+			if($world->getBlock($this->position->getSide($face)) instanceof Water){
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/block/DriedGhast.php
+++ b/src/block/DriedGhast.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\HorizontalFacing;
+use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\HappyGhast;
@@ -36,13 +38,18 @@ use pocketmine\world\BlockTransaction;
 use pocketmine\world\sound\GhastSound;
 use function mt_rand;
 
-class DriedGhast extends Transparent{
-	private const UPDATE_INTERVAL_TICKS = 40;
+class DriedGhast extends Transparent implements HorizontalFacing{
+	use HorizontalFacingTrait {
+		describeBlockOnlyState as describeFacingState;
+	}
+
+	private const UPDATE_INTERVAL_TICKS = 1200;
 	private const MAX_REHYDRATION_LEVEL = 3;
 
 	private int $rehydrationLevel = 0;
 
 	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
+		$this->describeFacingState($w);
 		$w->boundedIntAuto(0, self::MAX_REHYDRATION_LEVEL, $this->rehydrationLevel);
 	}
 
@@ -74,6 +81,9 @@ class DriedGhast extends Transparent{
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		$this->rehydrationLevel = 0;
+		if($player !== null){
+			$this->setFacing(Facing::opposite($player->getHorizontalFacing()));
+		}
 		$placed = parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		if($placed){
 			$this->scheduleHydrationTick();
@@ -111,6 +121,7 @@ class DriedGhast extends Transparent{
 				mt_rand(0, 359),
 				0
 			));
+			$happyGhast->setBaby();
 			$happyGhast->spawnToAll();
 			$world->addSound($this->position, new GhastSound());
 			return;

--- a/src/block/SnifferEgg.php
+++ b/src/block/SnifferEgg.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\CrackedState;
+use pocketmine\block\utils\SupportType;
+use pocketmine\data\runtime\RuntimeDataDescriber;
+use pocketmine\entity\Location;
+use pocketmine\entity\Sniffer;
+use pocketmine\item\Item;
+use pocketmine\math\AxisAlignedBB;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\BlockTransaction;
+use function mt_rand;
+
+class SnifferEgg extends Transparent{
+	private const UPDATE_INTERVAL_TICKS = 1200;
+
+	protected CrackedState $crackedState = CrackedState::NO_CRACKS;
+
+	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
+		$w->enum($this->crackedState);
+	}
+
+	public function getCrackedState() : CrackedState{
+		return $this->crackedState;
+	}
+
+	/** @return $this */
+	public function setCrackedState(CrackedState $crackedState) : self{
+		$this->crackedState = $crackedState;
+		return $this;
+	}
+
+	protected function recalculateCollisionBoxes() : array{
+		return [
+			AxisAlignedBB::one()
+				->contract(0.125, 0, 0.125)
+				->trim(Facing::UP, 0.125)
+		];
+	}
+
+	public function getSupportType(int $facing) : SupportType{
+		return SupportType::NONE;
+	}
+
+	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
+		$this->crackedState = CrackedState::NO_CRACKS;
+		$placed = parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		if($placed){
+			$this->scheduleHatchTick();
+		}
+
+		return $placed;
+	}
+
+	public function onScheduledUpdate() : void{
+		$world = $this->position->getWorld();
+		if($this->crackedState !== CrackedState::MAX_CRACKED){
+			$world->setBlock($this->position, $this->setCrackedState(match($this->crackedState){
+				CrackedState::NO_CRACKS => CrackedState::CRACKED,
+				CrackedState::CRACKED => CrackedState::MAX_CRACKED,
+				CrackedState::MAX_CRACKED => CrackedState::MAX_CRACKED,
+			}));
+			$this->scheduleHatchTick();
+			return;
+		}
+
+		$world->setBlock($this->position, VanillaBlocks::AIR());
+		$sniffer = new Sniffer(Location::fromObject(
+			$this->position->add(0.5, 0.5, 0.5),
+			$world,
+			mt_rand(0, 359),
+			0
+		));
+		$sniffer->setBaby();
+		$sniffer->spawnToAll();
+	}
+
+	private function scheduleHatchTick() : void{
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, self::UPDATE_INTERVAL_TICKS);
+	}
+}

--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -983,7 +983,9 @@ final class VanillaBlocks
 		self::register("carrots", fn(BID $id) => new Carrot($id, "Carrot Block", new Info(BreakInfo::instant())));
 
 		$chestBreakInfo = new Info(BreakInfo::axe(2.5));
+		$copperChestBreakInfo = new Info(BreakInfo::pickaxe(2.5, ToolTier::WOOD, 12.5));
 		self::register("chest", fn(BID $id) => new Chest($id, "Chest", $chestBreakInfo), TileChest::class);
+		self::register("copper_chest", fn(BID $id) => new CopperChest($id, "Copper Chest", $copperChestBreakInfo), TileChest::class);
 		self::register("clay", fn(BID $id) => new Clay($id, "Clay Block", new Info(BreakInfo::shovel(0.6))));
 		self::register("coal", fn(BID $id) => new Coal($id, "Coal Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 30.0))));
 
@@ -1013,6 +1015,7 @@ final class VanillaBlocks
 		self::register("pitcher_crop", fn(BID $id) => new PitcherCrop($id, "Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("double_pitcher_crop", fn(BID $id) => new DoublePitcherCrop($id, "Double Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("dragon_egg", fn(BID $id) => new DragonEgg($id, "Dragon Egg", new Info(BreakInfo::pickaxe(3.0, ToolTier::WOOD, blastResistance: 45.0))));
+		self::register("dried_ghast", fn(BID $id) => new DriedGhast($id, "Dried Ghast", new Info(new BreakInfo(0.8))));
 		self::register("dried_kelp", fn(BID $id) => new DriedKelp($id, "Dried Kelp Block", new Info(new BreakInfo(0.5, ToolType::NONE, 0, 12.5))));
 		self::register("emerald", fn(BID $id) => new Opaque($id, "Emerald Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::IRON, 30.0))));
 		self::register("enchanting_table", fn(BID $id) => new EnchantingTable($id, "Enchanting Table", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 6000.0))), TileEnchantingTable::class);

--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -768,6 +768,7 @@ use function strtolower;
  * @method static SmallDripleaf SMALL_DRIPLEAF()
  * @method static SmithingTable SMITHING_TABLE()
  * @method static Furnace SMOKER()
+ * @method static SnifferEgg SNIFFER_EGG()
  * @method static Opaque SMOOTH_BASALT()
  * @method static Opaque SMOOTH_QUARTZ()
  * @method static Slab SMOOTH_QUARTZ_SLAB()
@@ -1016,6 +1017,7 @@ final class VanillaBlocks
 		self::register("double_pitcher_crop", fn(BID $id) => new DoublePitcherCrop($id, "Double Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("dragon_egg", fn(BID $id) => new DragonEgg($id, "Dragon Egg", new Info(BreakInfo::pickaxe(3.0, ToolTier::WOOD, blastResistance: 45.0))));
 		self::register("dried_ghast", fn(BID $id) => new DriedGhast($id, "Dried Ghast", new Info(new BreakInfo(0.8))));
+		self::register("sniffer_egg", fn(BID $id) => new SnifferEgg($id, "Sniffer Egg", new Info(new BreakInfo(0.5))));
 		self::register("dried_kelp", fn(BID $id) => new DriedKelp($id, "Dried Kelp Block", new Info(new BreakInfo(0.5, ToolType::NONE, 0, 12.5))));
 		self::register("emerald", fn(BID $id) => new Opaque($id, "Emerald Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::IRON, 30.0))));
 		self::register("enchanting_table", fn(BID $id) => new EnchantingTable($id, "Enchanting Table", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 6000.0))), TileEnchantingTable::class);

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -184,7 +184,9 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("carrots", fn(BID $id) => new Carrot($id, "Carrot Block", new Info(BreakInfo::instant())));
 
 		$chestBreakInfo = new Info(BreakInfo::axe(2.5));
+		$copperChestBreakInfo = new Info(BreakInfo::pickaxe(2.5, ToolTier::WOOD, 12.5));
 		self::register("chest", fn(BID $id) => new Chest($id, "Chest", $chestBreakInfo), TileChest::class);
+		self::register("copper_chest", fn(BID $id) => new CopperChest($id, "Copper Chest", $copperChestBreakInfo), TileChest::class);
 		self::register("clay", fn(BID $id) => new Clay($id, "Clay Block", new Info(BreakInfo::shovel(0.6))));
 		self::register("coal", fn(BID $id) => new Coal($id, "Coal Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 30.0))));
 
@@ -214,6 +216,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("pitcher_crop", fn(BID $id) => new PitcherCrop($id, "Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("double_pitcher_crop", fn(BID $id) => new DoublePitcherCrop($id, "Double Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("dragon_egg", fn(BID $id) => new DragonEgg($id, "Dragon Egg", new Info(BreakInfo::pickaxe(3.0, ToolTier::WOOD, blastResistance: 45.0))));
+		self::register("dried_ghast", fn(BID $id) => new DriedGhast($id, "Dried Ghast", new Info(new BreakInfo(0.8))));
 		self::register("dried_kelp", fn(BID $id) => new DriedKelp($id, "Dried Kelp Block", new Info(new BreakInfo(0.5, ToolType::NONE, 0, 12.5))));
 		self::register("emerald", fn(BID $id) => new Opaque($id, "Emerald Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::IRON, 30.0))));
 		self::register("enchanting_table", fn(BID $id) => new EnchantingTable($id, "Enchanting Table", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 6000.0))), TileEnchantingTable::class);

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -217,6 +217,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("double_pitcher_crop", fn(BID $id) => new DoublePitcherCrop($id, "Double Pitcher Crop", new Info(BreakInfo::instant())));
 		self::register("dragon_egg", fn(BID $id) => new DragonEgg($id, "Dragon Egg", new Info(BreakInfo::pickaxe(3.0, ToolTier::WOOD, blastResistance: 45.0))));
 		self::register("dried_ghast", fn(BID $id) => new DriedGhast($id, "Dried Ghast", new Info(new BreakInfo(0.8))));
+		self::register("sniffer_egg", fn(BID $id) => new SnifferEgg($id, "Sniffer Egg", new Info(new BreakInfo(0.5))));
 		self::register("dried_kelp", fn(BID $id) => new DriedKelp($id, "Dried Kelp Block", new Info(new BreakInfo(0.5, ToolType::NONE, 0, 12.5))));
 		self::register("emerald", fn(BID $id) => new Opaque($id, "Emerald Block", new Info(BreakInfo::pickaxe(5.0, ToolTier::IRON, 30.0))));
 		self::register("enchanting_table", fn(BID $id) => new EnchantingTable($id, "Enchanting Table", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD, 6000.0))), TileEnchantingTable::class);

--- a/src/block/utils/CrackedState.php
+++ b/src/block/utils/CrackedState.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block\utils;
+
+use pocketmine\utils\LegacyEnumShimTrait;
+
+/**
+ * TODO: These tags need to be removed once we get rid of LegacyEnumShimTrait (PM6)
+ *  These are retained for backwards compatibility only.
+ *
+ * @method static CrackedState CRACKED()
+ * @method static CrackedState MAX_CRACKED()
+ * @method static CrackedState NO_CRACKS()
+ */
+enum CrackedState{
+	use LegacyEnumShimTrait;
+
+	case NO_CRACKS;
+	case CRACKED;
+	case MAX_CRACKED;
+}

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
  */
 
 declare(strict_types=1);
@@ -49,6 +49,7 @@ use pocketmine\block\CopperLantern;
 use pocketmine\block\DaylightSensor;
 use pocketmine\block\DetectorRail;
 use pocketmine\block\Dirt;
+use pocketmine\block\DriedGhast;
 use pocketmine\block\DoublePitcherCrop;
 use pocketmine\block\DoublePlant;
 use pocketmine\block\EndPortalFrame;
@@ -231,6 +232,9 @@ final class VanillaBlockMappings
 		$reg->mapSimple(Blocks::DIAMOND_ORE(), Ids::DIAMOND_ORE);
 		$reg->mapSimple(Blocks::DIORITE(), Ids::DIORITE);
 		$reg->mapSimple(Blocks::DRAGON_EGG(), Ids::DRAGON_EGG);
+		$reg->mapModel(Model::create(Blocks::DRIED_GHAST(), Ids::DRIED_GHAST)->properties([
+			new IntProperty(StateNames::REHYDRATION_LEVEL, 0, 3, fn(DriedGhast $b) => $b->getRehydrationLevel(), fn(DriedGhast $b, int $v) => $b->setRehydrationLevel($v))
+		]));
 		$reg->mapSimple(Blocks::DRIED_KELP(), Ids::DRIED_KELP_BLOCK);
 		$reg->mapSimple(Blocks::DRIPSTONE_BLOCK(), Ids::DRIPSTONE_BLOCK);
 		$reg->mapSimple(Blocks::ELEMENT_ACTINIUM(), Ids::ELEMENT_89);
@@ -731,6 +735,11 @@ final class VanillaBlockMappings
 				])
 		);
 		$reg->mapFlattenedId(FlattenedIdModel::create(Blocks::CHISELED_COPPER())->idComponents([...$commonProperties->copperIdPrefixes, "chiseled_copper"]));
+		$reg->mapFlattenedId(
+			FlattenedIdModel::create(Blocks::COPPER_CHEST())
+				->idComponents([...$commonProperties->copperIdPrefixes, "copper_chest"])
+				->properties([$commonProperties->horizontalFacingCardinal])
+		);
 		$reg->mapFlattenedId(FlattenedIdModel::create(Blocks::COPPER_GRATE())->idComponents([...$commonProperties->copperIdPrefixes, "copper_grate"]));
 		$reg->mapFlattenedId(FlattenedIdModel::create(Blocks::CUT_COPPER())->idComponents([...$commonProperties->copperIdPrefixes, "cut_copper"]));
 		$reg->mapFlattenedId(

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -90,6 +90,7 @@ use pocketmine\block\Shelf;
 use pocketmine\block\SeaPickle;
 use pocketmine\block\SmallDripleaf;
 use pocketmine\block\SnowLayer;
+use pocketmine\block\SnifferEgg;
 use pocketmine\block\Sponge;
 use pocketmine\block\StraightOnlyRail;
 use pocketmine\block\Sugarcane;
@@ -101,6 +102,7 @@ use pocketmine\block\TripwireHook;
 use pocketmine\block\utils\BellAttachmentType;
 use pocketmine\block\utils\BrewingStandSlot;
 use pocketmine\block\utils\ChiseledBookshelfSlot;
+use pocketmine\block\utils\CrackedState;
 use pocketmine\block\utils\CopperOxidation;
 use pocketmine\block\utils\DirtType;
 use pocketmine\block\utils\DripleafState;
@@ -149,7 +151,7 @@ final class VanillaBlockMappings
 	public static function init(BlockSerializerDeserializerRegistrar $reg): void
 	{
 		$commonProperties = CommonProperties::getInstance();
-		self::registerSimpleIdOnlyMappings($reg);
+		self::registerSimpleIdOnlyMappings($reg, $commonProperties);
 		self::registerColoredMappings($reg, $commonProperties);
 		self::registerCandleMappings($reg, $commonProperties);
 		self::registerLeavesMappings($reg);
@@ -171,7 +173,7 @@ final class VanillaBlockMappings
 		self::registerSplitMappings($reg, $commonProperties);
 	}
 
-	private static function registerSimpleIdOnlyMappings(BlockSerializerDeserializerRegistrar $reg): void
+	private static function registerSimpleIdOnlyMappings(BlockSerializerDeserializerRegistrar $reg, CommonProperties $commonProperties): void
 	{
 		$reg->mapSimple(Blocks::AIR(), Ids::AIR);
 		$reg->mapSimple(Blocks::AMETHYST(), Ids::AMETHYST_BLOCK);
@@ -232,7 +234,20 @@ final class VanillaBlockMappings
 		$reg->mapSimple(Blocks::DIAMOND_ORE(), Ids::DIAMOND_ORE);
 		$reg->mapSimple(Blocks::DIORITE(), Ids::DIORITE);
 		$reg->mapSimple(Blocks::DRAGON_EGG(), Ids::DRAGON_EGG);
+		$reg->mapModel(Model::create(Blocks::SNIFFER_EGG(), Ids::SNIFFER_EGG)->properties([
+			new ValueFromStringProperty(
+				StateNames::CRACKED_STATE,
+				EnumFromRawStateMap::string(CrackedState::class, fn(CrackedState $v) => match($v){
+					CrackedState::NO_CRACKS => StringValues::CRACKED_STATE_NO_CRACKS,
+					CrackedState::CRACKED => StringValues::CRACKED_STATE_CRACKED,
+					CrackedState::MAX_CRACKED => StringValues::CRACKED_STATE_MAX_CRACKED
+				}),
+				fn(SnifferEgg $b) => $b->getCrackedState(),
+				fn(SnifferEgg $b, CrackedState $v) => $b->setCrackedState($v)
+			)
+		]));
 		$reg->mapModel(Model::create(Blocks::DRIED_GHAST(), Ids::DRIED_GHAST)->properties([
+			$commonProperties->horizontalFacingCardinal,
 			new IntProperty(StateNames::REHYDRATION_LEVEL, 0, 3, fn(DriedGhast $b) => $b->getRehydrationLevel(), fn(DriedGhast $b, int $v) => $b->setRehydrationLevel($v))
 		]));
 		$reg->mapSimple(Blocks::DRIED_KELP(), Ids::DRIED_KELP_BLOCK);

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -287,6 +287,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::FISHING_ROD, Items::FISHING_ROD());
 		$this->map1to1Item(Ids::FLINT, Items::FLINT());
 		$this->map1to1Item(Ids::FLINT_AND_STEEL, Items::FLINT_AND_STEEL());
+		$this->map1to1Item(Ids::GHAST_SPAWN_EGG, Items::GHAST_SPAWN_EGG());
 		$this->map1to1Item(Ids::GHAST_TEAR, Items::GHAST_TEAR());
 		$this->map1to1Item(Ids::GLASS_BOTTLE, Items::GLASS_BOTTLE());
 		$this->map1to1Item(Ids::GLISTERING_MELON_SLICE, Items::GLISTERING_MELON());
@@ -312,6 +313,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::HONEY_BOTTLE, Items::HONEY_BOTTLE());
 		$this->map1to1Item(Ids::HONEYCOMB, Items::HONEYCOMB());
 		$this->map1to1Item(Ids::HOST_ARMOR_TRIM_SMITHING_TEMPLATE, Items::HOST_ARMOR_TRIM_SMITHING_TEMPLATE());
+		$this->map1to1Item(Ids::HAPPY_GHAST_SPAWN_EGG, Items::HAPPY_GHAST_SPAWN_EGG());
 		$this->map1to1Item(Ids::ICE_BOMB, Items::ICE_BOMB());
 		$this->map1to1Item(Ids::INK_SAC, Items::INK_SAC());
 		$this->map1to1Item(Ids::IRON_AXE, Items::IRON_AXE());
@@ -424,6 +426,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::SHULKER_SHELL, Items::SHULKER_SHELL());
 		$this->map1to1Item(Ids::SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE, Items::SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$this->map1to1Item(Ids::SLIME_BALL, Items::SLIMEBALL());
+		$this->map1to1Item(Ids::SNIFFER_SPAWN_EGG, Items::SNIFFER_SPAWN_EGG());
 		$this->map1to1Item(Ids::SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE, Items::SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$this->map1to1Item(Ids::SNOWBALL, Items::SNOWBALL());
 		$this->map1to1Item(Ids::SPIDER_EYE, Items::SPIDER_EYE());

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -435,6 +435,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::SPRUCE_HANGING_SIGN, Items::SPRUCE_HANGING_SIGN());
 		$this->map1to1Item(Ids::SPRUCE_SIGN, Items::SPRUCE_SIGN());
 		$this->map1to1Item(Ids::SPYGLASS, Items::SPYGLASS());
+		$this->map1to1Item(Ids::CHICKEN_SPAWN_EGG, Items::CHICKEN_SPAWN_EGG());
 		$this->map1to1Item(Ids::BEE_SPAWN_EGG, Items::BEE_SPAWN_EGG());
 		$this->map1to1Item(Ids::SQUID_SPAWN_EGG, Items::SQUID_SPAWN_EGG());
 		$this->map1to1Item(Ids::STICK, Items::STICK());

--- a/src/entity/Chicken.php
+++ b/src/entity/Chicken.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\item\Item;
+use pocketmine\item\VanillaItems;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+use function atan2;
+use function mt_rand;
+use const M_PI;
+
+class Chicken extends Living{
+	private int $wanderCooldown = 0;
+	private float $wanderX = 0.0;
+	private float $wanderZ = 0.0;
+
+	public static function getNetworkTypeId() : string{ return EntityIds::CHICKEN; }
+
+	protected function getInitialSizeInfo() : EntitySizeInfo{
+		return new EntitySizeInfo(0.7, 0.4);
+	}
+
+	public function initEntity(CompoundTag $nbt) : void{
+		$this->setMaxHealth(4);
+		parent::initEntity($nbt);
+	}
+
+	public function getName() : string{
+		return "Chicken";
+	}
+
+	protected function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if(!$this->isAlive()){
+			return $hasUpdate;
+		}
+
+		$this->wanderCooldown -= $tickDiff;
+		if($this->wanderCooldown <= 0){
+			$this->wanderCooldown = mt_rand(30, 80);
+			$this->wanderX = mt_rand(-1000, 1000) / 1000;
+			$this->wanderZ = mt_rand(-1000, 1000) / 1000;
+		}
+
+		if($this->onGround){
+			$this->motion = $this->motion->withComponents($this->wanderX * 0.05, null, $this->wanderZ * 0.05);
+			if(($this->wanderX ** 2 + $this->wanderZ ** 2) > 0.0001){
+				$this->setRotation(-atan2($this->wanderX, $this->wanderZ) * 180 / M_PI, $this->location->pitch);
+			}
+			$hasUpdate = true;
+		}
+
+		return $hasUpdate;
+	}
+
+	public function getXpDropAmount() : int{
+		return 1;
+	}
+
+	public function getPickedItem() : ?Item{
+		return VanillaItems::CHICKEN_SPAWN_EGG();
+	}
+}

--- a/src/entity/EntityFactory.php
+++ b/src/entity/EntityFactory.php
@@ -199,6 +199,18 @@ final class EntityFactory{
 			return new Bee(Helper::parseLocation($nbt, $world), $nbt);
 		}, ['Bee', 'minecraft:bee']);
 
+		$this->register(Ghast::class, function(World $world, CompoundTag $nbt) : Ghast{
+			return new Ghast(Helper::parseLocation($nbt, $world), $nbt);
+		}, ['Ghast', 'minecraft:ghast']);
+
+		$this->register(HappyGhast::class, function(World $world, CompoundTag $nbt) : HappyGhast{
+			return new HappyGhast(Helper::parseLocation($nbt, $world), $nbt);
+		}, ['HappyGhast', 'minecraft:happy_ghast']);
+
+		$this->register(Sniffer::class, function(World $world, CompoundTag $nbt) : Sniffer{
+			return new Sniffer(Helper::parseLocation($nbt, $world), $nbt);
+		}, ['Sniffer', 'minecraft:sniffer']);
+
 		$this->register(Squid::class, function(World $world, CompoundTag $nbt) : Squid{
 			return new Squid(Helper::parseLocation($nbt, $world), $nbt);
 		}, ['Squid', 'minecraft:squid']);

--- a/src/entity/EntityFactory.php
+++ b/src/entity/EntityFactory.php
@@ -199,6 +199,10 @@ final class EntityFactory{
 			return new Bee(Helper::parseLocation($nbt, $world), $nbt);
 		}, ['Bee', 'minecraft:bee']);
 
+		$this->register(Chicken::class, function(World $world, CompoundTag $nbt) : Chicken{
+			return new Chicken(Helper::parseLocation($nbt, $world), $nbt);
+		}, ['Chicken', 'minecraft:chicken']);
+
 		$this->register(Ghast::class, function(World $world, CompoundTag $nbt) : Ghast{
 			return new Ghast(Helper::parseLocation($nbt, $world), $nbt);
 		}, ['Ghast', 'minecraft:ghast']);

--- a/src/entity/Ghast.php
+++ b/src/entity/Ghast.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\item\Item;
+use pocketmine\item\VanillaItems;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+use function mt_rand;
+
+class Ghast extends SimpleFlyingMob{
+
+	public static function getNetworkTypeId() : string{ return EntityIds::GHAST; }
+
+	protected function getInitialSizeInfo() : EntitySizeInfo{
+		return new EntitySizeInfo(4.0, 4.0);
+	}
+
+	public function initEntity(CompoundTag $nbt) : void{
+		$this->setMaxHealth(10);
+		parent::initEntity($nbt);
+	}
+
+	public function getName() : string{
+		return "Ghast";
+	}
+
+	protected function getFlightSpeed() : float{
+		return 0.12;
+	}
+
+	public function getDrops() : array{
+		$looting = $this->getLootingLevelForDrops();
+		$drops = [
+			VanillaItems::GUNPOWDER()->setCount(mt_rand(0, 2 + $looting))
+		];
+
+		if(mt_rand(0, 1) === 1){
+			$drops[] = VanillaItems::GHAST_TEAR()->setCount(mt_rand(1, 1 + $looting));
+		}
+
+		return $drops;
+	}
+
+	public function getXpDropAmount() : int{
+		return 5;
+	}
+
+	public function getPickedItem() : ?Item{
+		return VanillaItems::GHAST_SPAWN_EGG();
+	}
+}

--- a/src/entity/HappyGhast.php
+++ b/src/entity/HappyGhast.php
@@ -24,11 +24,27 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\item\Item;
+use pocketmine\item\SpawnEgg;
 use pocketmine\item\VanillaItems;
+use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\ActorEventPacket;
+use pocketmine\network\mcpe\protocol\types\ActorEvent;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
+use pocketmine\player\Player;
+use function min;
+use function mt_rand;
 
-class HappyGhast extends SimpleFlyingMob{
+class HappyGhast extends SimpleFlyingMob implements Ageable{
+	private const TAG_BABY = "Baby";
+	private const TAG_AGE = "Age";
+	private const BABY_GROW_TICKS = 24000;
+	private const BABY_SCALE = 0.5;
+
+	private bool $baby = false;
+	private int $ageTicks = 0;
 
 	public static function getNetworkTypeId() : string{ return EntityIds::HAPPY_GHAST; }
 
@@ -39,10 +55,70 @@ class HappyGhast extends SimpleFlyingMob{
 	public function initEntity(CompoundTag $nbt) : void{
 		$this->setMaxHealth(20);
 		parent::initEntity($nbt);
+
+		$this->baby = $nbt->getByte(self::TAG_BABY, 0) !== 0;
+		$this->ageTicks = $nbt->getInt(self::TAG_AGE, 0);
+		if($this->baby){
+			$this->setScale(self::BABY_SCALE);
+		}
+	}
+
+	public function saveNBT() : CompoundTag{
+		$nbt = parent::saveNBT();
+		$nbt->setByte(self::TAG_BABY, $this->baby ? 1 : 0);
+		$nbt->setInt(self::TAG_AGE, $this->ageTicks);
+		return $nbt;
 	}
 
 	public function getName() : string{
 		return "Happy Ghast";
+	}
+
+	public function isBaby() : bool{
+		return $this->baby;
+	}
+
+	public function setBaby(bool $baby = true) : void{
+		$this->baby = $baby;
+		$this->setScale($baby ? self::BABY_SCALE : 1.0);
+		$this->networkPropertiesDirty = true;
+	}
+
+	public function onInteract(Player $player, Vector3 $clickPos) : bool{
+		$item = $player->getInventory()->getItemInHand();
+
+		if($item instanceof SpawnEgg){
+			$baby = new self(Location::fromObject($this->location->add(0, 0.5, 0), $this->getWorld(), mt_rand(0, 360), 0));
+			$baby->setBaby();
+			$baby->spawnToAll();
+			if(!$player->isCreative()){
+				$item->pop();
+				$player->getInventory()->setItemInHand($item);
+			}
+			return true;
+		}
+
+		if($this->baby && $item->getTypeId() === VanillaItems::SNOWBALL()->getTypeId()){
+			$player->ignoreChargeableClickAirForTicks(1);
+			$player->resetItemCooldown($item, 2);
+
+			$this->ageTicks = min($this->ageTicks + (int) (self::BABY_GROW_TICKS * 0.1), self::BABY_GROW_TICKS);
+			if($this->ageTicks >= self::BABY_GROW_TICKS){
+				$this->setBaby(false);
+				$this->ageTicks = 0;
+			}
+			$this->getWorld()->broadcastPacketToViewers(
+				$this->location,
+				ActorEventPacket::create($this->getId(), ActorEvent::BABY_ANIMAL_FEED, 0)
+			);
+			if(!$player->isCreative()){
+				$item->pop();
+				$player->getInventory()->setItemInHand($item);
+			}
+			return true;
+		}
+
+		return parent::onInteract($player, $clickPos);
 	}
 
 	protected function getFlightSpeed() : float{
@@ -54,7 +130,26 @@ class HappyGhast extends SimpleFlyingMob{
 	}
 
 	public function getXpDropAmount() : int{
-		return 1;
+		return $this->baby ? 0 : 1;
+	}
+
+	protected function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if($this->baby && $this->isAlive()){
+			$this->ageTicks += $tickDiff;
+			if($this->ageTicks >= self::BABY_GROW_TICKS){
+				$this->setBaby(false);
+				$this->ageTicks = 0;
+			}
+		}
+
+		return $hasUpdate;
+	}
+
+	protected function syncNetworkData(EntityMetadataCollection $properties) : void{
+		parent::syncNetworkData($properties);
+		$properties->setGenericFlag(EntityMetadataFlags::BABY, $this->baby);
 	}
 
 	public function getPickedItem() : ?Item{

--- a/src/entity/HappyGhast.php
+++ b/src/entity/HappyGhast.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\item\Item;
+use pocketmine\item\VanillaItems;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class HappyGhast extends SimpleFlyingMob{
+
+	public static function getNetworkTypeId() : string{ return EntityIds::HAPPY_GHAST; }
+
+	protected function getInitialSizeInfo() : EntitySizeInfo{
+		return new EntitySizeInfo(3.0, 3.0);
+	}
+
+	public function initEntity(CompoundTag $nbt) : void{
+		$this->setMaxHealth(20);
+		parent::initEntity($nbt);
+	}
+
+	public function getName() : string{
+		return "Happy Ghast";
+	}
+
+	protected function getFlightSpeed() : float{
+		return 0.09;
+	}
+
+	protected function getVerticalMotionScale() : float{
+		return 0.35;
+	}
+
+	public function getXpDropAmount() : int{
+		return 1;
+	}
+
+	public function getPickedItem() : ?Item{
+		return VanillaItems::HAPPY_GHAST_SPAWN_EGG();
+	}
+}

--- a/src/entity/SimpleFlyingMob.php
+++ b/src/entity/SimpleFlyingMob.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\math\Vector3;
+use function atan2;
+use function mt_rand;
+use function sqrt;
+use const M_PI;
+
+abstract class SimpleFlyingMob extends Living{
+	private ?Vector3 $flightDirection = null;
+	private int $retargetTicks = 0;
+
+	protected function getInitialGravity() : float{
+		return 0.0;
+	}
+
+	protected function calculateFallDamage(float $fallDistance) : float{
+		return 0;
+	}
+
+	public function canBreathe() : bool{
+		return true;
+	}
+
+	abstract protected function getFlightSpeed() : float;
+
+	protected function getVerticalMotionScale() : float{
+		return 0.45;
+	}
+
+	protected function getRetargetInterval() : int{
+		return 60;
+	}
+
+	protected function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if(!$this->isAlive()){
+			return $hasUpdate;
+		}
+
+		$this->setHasGravity(false);
+
+		$this->retargetTicks -= $tickDiff;
+		if($this->flightDirection === null || $this->retargetTicks <= 0){
+			$this->flightDirection = $this->createFlightDirection();
+			$this->retargetTicks = $this->getRetargetInterval();
+		}
+
+		$direction = $this->flightDirection;
+		if($direction !== null){
+			$motion = $this->motion->multiply(0.7)->addVector($direction->multiply($this->getFlightSpeed() * 0.3));
+			if($this->isUnderwater() && $motion->y < 0.08){
+				$motion = $motion->withComponents(null, 0.08, null);
+			}
+
+			$this->motion = $motion;
+			$horizontal = sqrt(($motion->x ** 2) + ($motion->z ** 2));
+			if($horizontal > self::MOTION_THRESHOLD){
+				$this->setRotation(
+					-atan2($motion->x, $motion->z) * 180 / M_PI,
+					-atan2($horizontal, $motion->y) * 180 / M_PI
+				);
+			}
+			$hasUpdate = true;
+		}
+
+		return $hasUpdate;
+	}
+
+	private function createFlightDirection() : Vector3{
+		$x = mt_rand(-1000, 1000) / 1000;
+		$y = mt_rand(-1000, 1000) / 1000 * $this->getVerticalMotionScale();
+		$z = mt_rand(-1000, 1000) / 1000;
+
+		$direction = new Vector3($x, $y, $z);
+		if($direction->lengthSquared() <= 0.0001){
+			return new Vector3(0, 0.1, 0);
+		}
+
+		return $direction->normalize();
+	}
+}

--- a/src/entity/Sniffer.php
+++ b/src/entity/Sniffer.php
@@ -24,17 +24,27 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\item\Item;
+use pocketmine\item\SpawnEgg;
 use pocketmine\item\VanillaItems;
+use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
+use pocketmine\player\Player;
 use function atan2;
+use function min;
 use function mt_rand;
 use const M_PI;
 
 class Sniffer extends Living implements Ageable{
+	private const TAG_BABY = "Baby";
+	private const TAG_AGE = "Age";
+	private const BABY_GROW_TICKS = 20 * 60 * 20;
+	private const BABY_SCALE = 0.5;
+
 	protected bool $baby = false;
+	private int $ageTicks = 0;
 
 	private int $wanderCooldown = 0;
 	private float $wanderX = 0.0;
@@ -49,6 +59,19 @@ class Sniffer extends Living implements Ageable{
 	public function initEntity(CompoundTag $nbt) : void{
 		$this->setMaxHealth(14);
 		parent::initEntity($nbt);
+		$this->baby = $nbt->getByte(self::TAG_BABY, 0) !== 0;
+		$this->ageTicks = $nbt->getInt(self::TAG_AGE, 0);
+
+		if($this->baby){
+			$this->setScale(self::BABY_SCALE);
+		}
+	}
+
+	public function saveNBT() : CompoundTag{
+		$nbt = parent::saveNBT();
+		$nbt->setByte(self::TAG_BABY, $this->baby ? 1 : 0);
+		$nbt->setInt(self::TAG_AGE, $this->ageTicks);
+		return $nbt;
 	}
 
 	public function getName() : string{
@@ -59,11 +82,42 @@ class Sniffer extends Living implements Ageable{
 		return $this->baby;
 	}
 
+	public function setBaby(bool $baby = true) : void{
+		$this->baby = $baby;
+		$this->setScale($baby ? self::BABY_SCALE : 1.0);
+		$this->networkPropertiesDirty = true;
+	}
+
+	public function onInteract(Player $player, Vector3 $clickPos) : bool{
+		$item = $player->getInventory()->getItemInHand();
+
+		if($item instanceof SpawnEgg){
+			$baby = new self(Location::fromObject($this->location->add(0, 0.5, 0), $this->getWorld(), mt_rand(0, 360), 0));
+			$baby->setBaby();
+			$baby->spawnToAll();
+			if(!$player->isCreative()){
+				$item->pop();
+				$player->getInventory()->setItemInHand($item);
+			}
+			return true;
+		}
+
+		return parent::onInteract($player, $clickPos);
+	}
+
 	protected function entityBaseTick(int $tickDiff = 1) : bool{
 		$hasUpdate = parent::entityBaseTick($tickDiff);
 
 		if(!$this->isAlive()){
 			return $hasUpdate;
+		}
+
+		if($this->baby){
+			$this->ageTicks = min($this->ageTicks + $tickDiff, self::BABY_GROW_TICKS);
+			if($this->ageTicks >= self::BABY_GROW_TICKS){
+				$this->setBaby(false);
+				$this->ageTicks = 0;
+			}
 		}
 
 		$this->wanderCooldown -= $tickDiff;
@@ -90,7 +144,7 @@ class Sniffer extends Living implements Ageable{
 	}
 
 	public function getXpDropAmount() : int{
-		return 3;
+		return $this->baby ? 0 : 3;
 	}
 
 	public function getPickedItem() : ?Item{

--- a/src/entity/Sniffer.php
+++ b/src/entity/Sniffer.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ *     ____            ____        __  ____
+ *    / __ )___  ___  / / /___  __/  |/  (_)___  ___
+ *   / __  / _ \/ _ \/ / __/ / / / /|_/ / / __ \/ _ \
+ *  / /_/ /  __/  __/ / /_/ /_/ / /  / / / / / /  __/
+ * /_____/\___/\___/_/\__/\__, /_/  /_/_/_/ /_/\___/
+ *                       /____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author Ayrz
+ * @team BeeltyMine
+ * 
+ * 
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\item\Item;
+use pocketmine\item\VanillaItems;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
+use function atan2;
+use function mt_rand;
+use const M_PI;
+
+class Sniffer extends Living implements Ageable{
+	protected bool $baby = false;
+
+	private int $wanderCooldown = 0;
+	private float $wanderX = 0.0;
+	private float $wanderZ = 0.0;
+
+	public static function getNetworkTypeId() : string{ return EntityIds::SNIFFER; }
+
+	protected function getInitialSizeInfo() : EntitySizeInfo{
+		return new EntitySizeInfo(1.75, 1.9);
+	}
+
+	public function initEntity(CompoundTag $nbt) : void{
+		$this->setMaxHealth(14);
+		parent::initEntity($nbt);
+	}
+
+	public function getName() : string{
+		return "Sniffer";
+	}
+
+	public function isBaby() : bool{
+		return $this->baby;
+	}
+
+	protected function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if(!$this->isAlive()){
+			return $hasUpdate;
+		}
+
+		$this->wanderCooldown -= $tickDiff;
+		if($this->wanderCooldown <= 0){
+			$this->wanderCooldown = mt_rand(40, 100);
+			$this->wanderX = mt_rand(-1000, 1000) / 1000;
+			$this->wanderZ = mt_rand(-1000, 1000) / 1000;
+		}
+
+		if($this->onGround){
+			$this->motion = $this->motion->withComponents($this->wanderX * 0.08, null, $this->wanderZ * 0.08);
+			if(($this->wanderX ** 2 + $this->wanderZ ** 2) > 0.0001){
+				$this->setRotation(-atan2($this->wanderX, $this->wanderZ) * 180 / M_PI, $this->location->pitch);
+			}
+			$hasUpdate = true;
+		}
+
+		return $hasUpdate;
+	}
+
+	protected function syncNetworkData(EntityMetadataCollection $properties) : void{
+		parent::syncNetworkData($properties);
+		$properties->setGenericFlag(EntityMetadataFlags::BABY, $this->baby);
+	}
+
+	public function getXpDropAmount() : int{
+		return 3;
+	}
+
+	public function getPickedItem() : ?Item{
+		return VanillaItems::SNIFFER_SPAWN_EGG();
+	}
+}

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -394,6 +394,7 @@ final class ItemTypeIds{
 	public const GHAST_SPAWN_EGG = 20352;
 	public const HAPPY_GHAST_SPAWN_EGG = 20353;
 	public const SNIFFER_SPAWN_EGG = 20354;
+	public const CHICKEN_SPAWN_EGG = 20355;
 
 	public const FIRST_UNUSED_ITEM_ID = 20900;
 

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -391,6 +391,9 @@ final class ItemTypeIds{
 	public const MAGENTA_BUNDLE = 20349;
 	public const PINK_BUNDLE = 20350;
 	public const CROSSBOW = 20351;
+	public const GHAST_SPAWN_EGG = 20352;
+	public const HAPPY_GHAST_SPAWN_EGG = 20353;
+	public const SNIFFER_SPAWN_EGG = 20354;
 
 	public const FIRST_UNUSED_ITEM_ID = 20900;
 

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1460,6 +1460,7 @@ final class StringToItemParser extends StringToTParser
 		$result->register("glow_berries", fn() => Items::GLOW_BERRIES());
 		$result->register("glow_ink_sac", fn() => Items::GLOW_INK_SAC());
 		$result->register("glowstone_dust", fn() => Items::GLOWSTONE_DUST());
+		$result->register("ghast_spawn_egg", fn() => Items::GHAST_SPAWN_EGG());
 		$result->register("goat_horn", fn() => Items::GOAT_HORN());
 		$result->register("gold_axe", fn() => Items::GOLDEN_AXE());
 		$result->register("gold_boots", fn() => Items::GOLDEN_BOOTS());
@@ -1619,6 +1620,7 @@ final class StringToItemParser extends StringToTParser
 		$result->register("shears", fn() => Items::SHEARS());
 		$result->register("shulker_shell", fn() => Items::SHULKER_SHELL());
 		$result->register("silence_armor_trim_smithing_template", fn() => Items::SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE());
+		$result->register("sniffer_spawn_egg", fn() => Items::SNIFFER_SPAWN_EGG());
 		$result->register("slime_ball", fn() => Items::SLIMEBALL());
 		$result->register("snout_armor_trim_smithing_template", fn() => Items::SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$result->register("slimeball", fn() => Items::SLIMEBALL());
@@ -1654,6 +1656,7 @@ final class StringToItemParser extends StringToTParser
 		$result->register("vex_armor_trim_smithing_template", fn() => Items::VEX_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$result->register("turtle_shell_piece", fn() => Items::SCUTE());
 		$result->register("villager_spawn_egg", fn() => Items::VILLAGER_SPAWN_EGG());
+		$result->register("happy_ghast_spawn_egg", fn() => Items::HAPPY_GHAST_SPAWN_EGG());
 		$result->register("ward_armor_trim_smithing_template", fn() => Items::WARD_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$result->register("warped_hanging_sign", fn() => Items::WARPED_HANGING_SIGN());
 		$result->register("water_bucket", fn() => Items::WATER_BUCKET());

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -424,6 +424,8 @@ final class StringToItemParser extends StringToTParser
 		$result->registerBlock("double_wooden_slabs", fn() => Blocks::OAK_SLAB()->setSlabType(SlabType::DOUBLE));
 		$result->registerBlock("dragon_egg", fn() => Blocks::DRAGON_EGG());
 		$result->registerBlock("dragon_head", fn() => Blocks::MOB_HEAD()->setMobHeadType(MobHeadType::DRAGON));
+		$result->registerBlock("dried_ghast", fn() => Blocks::DRIED_GHAST());
+		$result->registerBlock("sniffer_egg", fn() => Blocks::SNIFFER_EGG());
 		$result->registerBlock("dried_kelp_block", fn() => Blocks::DRIED_KELP());
 		$result->registerBlock("dripstone_block", fn() => Blocks::DRIPSTONE_BLOCK());
 		$result->registerBlock("dyed_shulker_box", fn() => Blocks::DYED_SHULKER_BOX());
@@ -1632,6 +1634,7 @@ final class StringToItemParser extends StringToTParser
 		$result->register("spruce_boat", fn() => Items::SPRUCE_BOAT());
 		$result->register("spruce_hanging_sign", fn() => Items::SPRUCE_HANGING_SIGN());
 		$result->register("spyglass", fn() => Items::SPYGLASS());
+		$result->register("chicken_spawn_egg", fn() => Items::CHICKEN_SPAWN_EGG());
 		$result->register("bee_spawn_egg", fn() => Items::BEE_SPAWN_EGG());
 		$result->register("squid_spawn_egg", fn() => Items::SQUID_SPAWN_EGG());
 		$result->register("steak", fn() => Items::STEAK());

--- a/src/item/VanillaItems.php
+++ b/src/item/VanillaItems.php
@@ -26,6 +26,7 @@ namespace pocketmine\item;
 use pocketmine\block\utils\RecordType;
 use pocketmine\block\VanillaBlocks as Blocks;
 use pocketmine\entity\Bee;
+use pocketmine\entity\Chicken;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Ghast;
 use pocketmine\entity\HappyGhast;
@@ -82,6 +83,7 @@ use function strtolower;
  * @method static Bread BREAD()
  * @method static Item BRICK()
  * @method static Bucket BUCKET()
+ * @method static SpawnEgg CHICKEN_SPAWN_EGG()
  * @method static Bundle BUNDLE()
  * @method static Bundle WHITE_BUNDLE()
  * @method static Bundle LIGHT_GRAY_BUNDLE()
@@ -724,6 +726,11 @@ final class VanillaItems{
 		self::register("zombie_spawn_egg", fn(IID $id) => new class($id, "Zombie Spawn Egg") extends SpawnEgg{
 			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
 				return new Zombie(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("chicken_spawn_egg", fn(IID $id) => new class($id, "Chicken Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Chicken(Location::fromObject($pos, $world, $yaw, $pitch));
 			}
 		});
 		self::register("bee_spawn_egg", fn(IID $id) => new class($id, "Bee Spawn Egg") extends SpawnEgg{

--- a/src/item/VanillaItems.php
+++ b/src/item/VanillaItems.php
@@ -27,7 +27,10 @@ use pocketmine\block\utils\RecordType;
 use pocketmine\block\VanillaBlocks as Blocks;
 use pocketmine\entity\Bee;
 use pocketmine\entity\Entity;
+use pocketmine\entity\Ghast;
+use pocketmine\entity\HappyGhast;
 use pocketmine\entity\Location;
+use pocketmine\entity\Sniffer;
 use pocketmine\entity\Squid;
 use pocketmine\entity\Villager;
 use pocketmine\entity\Zombie;
@@ -726,6 +729,21 @@ final class VanillaItems{
 		self::register("bee_spawn_egg", fn(IID $id) => new class($id, "Bee Spawn Egg") extends SpawnEgg{
 			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
 				return new Bee(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("ghast_spawn_egg", fn(IID $id) => new class($id, "Ghast Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Ghast(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("happy_ghast_spawn_egg", fn(IID $id) => new class($id, "Happy Ghast Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new HappyGhast(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("sniffer_spawn_egg", fn(IID $id) => new class($id, "Sniffer Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Sniffer(Location::fromObject($pos, $world, $yaw, $pitch));
 			}
 		});
 		self::register("squid_spawn_egg", fn(IID $id) => new class($id, "Squid Spawn Egg") extends SpawnEgg{

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -27,6 +27,7 @@ namespace pocketmine\item;
 use pocketmine\block\utils\RecordType;
 use pocketmine\block\VanillaBlocks as Blocks;
 use pocketmine\entity\Bee;
+use pocketmine\entity\Chicken;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Ghast;
 use pocketmine\entity\HappyGhast;
@@ -368,6 +369,11 @@ final class VanillaItemsInputs extends RegistrySource{
 		self::register("zombie_spawn_egg", fn(IID $id) => new class($id, "Zombie Spawn Egg") extends SpawnEgg{
 			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
 				return new Zombie(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("chicken_spawn_egg", fn(IID $id) => new class($id, "Chicken Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Chicken(Location::fromObject($pos, $world, $yaw, $pitch));
 			}
 		});
 		self::register("bee_spawn_egg", fn(IID $id) => new class($id, "Bee Spawn Egg") extends SpawnEgg{

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -28,7 +28,10 @@ use pocketmine\block\utils\RecordType;
 use pocketmine\block\VanillaBlocks as Blocks;
 use pocketmine\entity\Bee;
 use pocketmine\entity\Entity;
+use pocketmine\entity\Ghast;
+use pocketmine\entity\HappyGhast;
 use pocketmine\entity\Location;
+use pocketmine\entity\Sniffer;
 use pocketmine\entity\Squid;
 use pocketmine\entity\Villager;
 use pocketmine\entity\Zombie;
@@ -370,6 +373,21 @@ final class VanillaItemsInputs extends RegistrySource{
 		self::register("bee_spawn_egg", fn(IID $id) => new class($id, "Bee Spawn Egg") extends SpawnEgg{
 			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
 				return new Bee(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("ghast_spawn_egg", fn(IID $id) => new class($id, "Ghast Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Ghast(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("happy_ghast_spawn_egg", fn(IID $id) => new class($id, "Happy Ghast Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new HappyGhast(Location::fromObject($pos, $world, $yaw, $pitch));
+			}
+		});
+		self::register("sniffer_spawn_egg", fn(IID $id) => new class($id, "Sniffer Spawn Egg") extends SpawnEgg{
+			protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity{
+				return new Sniffer(Location::fromObject($pos, $world, $yaw, $pitch));
 			}
 		});
 		self::register("squid_spawn_egg", fn(IID $id) => new class($id, "Squid Spawn Egg") extends SpawnEgg{

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -32,6 +32,7 @@ use pocketmine\block\tile\Sign;
 use pocketmine\block\utils\SignText;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\Entity;
+use pocketmine\entity\HappyGhast;
 use pocketmine\entity\InvalidSkinException;
 use pocketmine\event\player\PlayerEditBookEvent;
 use pocketmine\inventory\transaction\action\DropItemAction;
@@ -144,6 +145,7 @@ class InGamePacketHandler extends PacketHandler{
 	private const MAX_FORM_RESPONSE_SIZE = 10 * 1024; //10 KiB should be more than enough
 	private const MAX_FORM_RESPONSE_DEPTH = 2; //modal/simple will be 1, custom forms 2 - they will never contain anything other than string|int|float|bool|null
 	private const SPEAR_TRACE_FALLBACK_MIN_DOT = 0.55;
+	private const SNOWBALL_AIR_SUPPRESSION_WINDOW = 0.2;
 
 	//TODO: The client-side per-page character limit is inconsistent for non-ASCII text,
 	//allowing input beyond 256 chars. Use a slightly higher bounded soft limit to
@@ -152,6 +154,7 @@ class InGamePacketHandler extends PacketHandler{
 
 	protected float $lastRightClickTime = 0.0;
 	protected ?UseItemTransactionData $lastRightClickData = null;
+	protected float $suppressSnowballClickAirUntil = 0.0;
 
 	protected ?Vector3 $lastPlayerAuthInputPosition = null;
 	protected ?float $lastPlayerAuthInputYaw = null;
@@ -622,7 +625,13 @@ class InGamePacketHandler extends PacketHandler{
 				}
 				return true;
 			case UseItemTransactionData::ACTION_CLICK_AIR:
+				if($this->shouldSuppressSnowballClickAirAfterEntityFeed()){
+					return true;
+				}
 				if($this->player->shouldIgnoreChargeableClickAir()){
+					return true;
+				}
+				if($this->shouldSuppressSnowballThrowForBabyHappyGhastFeed()){
 					return true;
 				}
 				if($this->player->isUsingItem()){
@@ -642,6 +651,49 @@ class InGamePacketHandler extends PacketHandler{
 					return $this->executeSpearJab();
 				}
 				return $this->player->useHeldItem();
+		}
+
+		return false;
+	}
+
+	private function shouldSuppressSnowballClickAirAfterEntityFeed() : bool{
+		if(microtime(true) > $this->suppressSnowballClickAirUntil){
+			return false;
+		}
+
+		return $this->player->getInventory()->getItemInHand()->getTypeId() === VanillaItems::SNOWBALL()->getTypeId();
+	}
+
+	private function shouldSuppressSnowballThrowForBabyHappyGhastFeed() : bool{
+		$itemInHand = $this->player->getInventory()->getItemInHand();
+		if($itemInHand->getTypeId() !== VanillaItems::SNOWBALL()->getTypeId()){
+			return false;
+		}
+
+		$maxDistance = 10.0;
+		$eyePos = $this->player->getEyePos();
+		$direction = $this->player->getDirectionVector()->normalize();
+		$traceEnd = $eyePos->addVector($direction->multiply($maxDistance));
+		$searchBox = $this->player->getBoundingBox()->expandedCopy($maxDistance, $maxDistance, $maxDistance);
+
+		foreach($this->player->getWorld()->getNearbyEntities($searchBox, $this->player) as $entity){
+			if(!($entity instanceof HappyGhast) || !$entity->isBaby() || !$entity->isAlive() || $entity->isFlaggedForDespawn()){
+				continue;
+			}
+			if(!$this->player->canInteract($entity->getLocation(), $maxDistance)){
+				continue;
+			}
+
+			$targetPos = $entity->getPosition()->add(0, $entity->size->getHeight() / 2, 0);
+			$toEntity = $targetPos->subtractVector($eyePos);
+			if($toEntity->lengthSquared() <= 0.0001){
+				return true;
+			}
+			if($entity->getBoundingBox()->expandedCopy(0.5, 0.5, 0.5)->calculateIntercept($eyePos, $traceEnd) === null){
+				continue;
+			}
+
+			return true;
 		}
 
 		return false;
@@ -797,7 +849,16 @@ class InGamePacketHandler extends PacketHandler{
 				if($heldItem instanceof Releasable && $this->player->isUsingItem()){
 					return true;
 				}
-				if(!$this->player->interactEntity($target, $data->getClickPosition()) && $heldItem instanceof Releasable){
+				$interacted = $this->player->interactEntity($target, $data->getClickPosition());
+				if(
+					$interacted &&
+					$heldItem->getTypeId() === VanillaItems::SNOWBALL()->getTypeId() &&
+					$target instanceof HappyGhast &&
+					$target->isBaby()
+				){
+					$this->suppressSnowballClickAirUntil = microtime(true) + self::SNOWBALL_AIR_SUPPRESSION_WINDOW;
+				}
+				if(!$interacted && $heldItem instanceof Releasable){
 					return $this->player->useHeldItem();
 				}
 				return true;


### PR DESCRIPTION
Adds Ghast, HappyGhast, and Sniffer entity support together with required assets, SnifferEgg/Chicken integration, Copper Chest content, and baby growth/spawn mechanics.

This PR is needed to complete missing gameplay/content coverage for newly added entities and related blocks/items, and to wire them into spawning, interaction, persistence, and creative/game registries.

### Related issues & PRs
- N/A

## Changes
### API changes
- Added support for new entity/content registrations used by Ghast, HappyGhast, Sniffer, Chicken, SnifferEgg, and Copper Chest related content.
- Added parser/serialization/runtime integration required for the new content paths where applicable.

### Behavioural changes
- Added `Ghast`, `HappyGhast`, and `Sniffer` gameplay/entity integration.
- Added required assets and content wiring for the new entities.
- Added `SnifferEgg` gameplay flow, including staged cracking and delayed hatching.
- Added `Chicken` spawn egg integration.
- Added baby-state mechanics for supported entities, including spawn, persistence, and natural growth flow.
- Added interaction support for baby spawning via spawn eggs where applicable.
- Added Copper Chest related content/integration.
- Improved creative/registry visibility and content grouping for newly added blocks/items where applicable.

## Backwards compatibility
- No intentional breaking API changes.
- Existing worlds should continue to load, while newly added content becomes available through the updated registries, parsers, and runtime mappings.

## Follow-up
- Verify Bedrock parity for all newly added entities/blocks/items and their blockstate/runtime mappings.
- Add any remaining missing sounds, particles, loot tables, or edge-case interactions if needed.
- Continue expanding baby/entity interaction coverage for remaining vanilla content.

## Tests
- Manually tested entity spawning for `Ghast`, `HappyGhast`, `Sniffer`, and `Chicken`.
- Manually tested baby spawn flow using spawn eggs where supported.
- Manually tested `SnifferEgg` placement, crack progression, and hatch flow.
- Manually tested persistence/reload behaviour for newly added entities and baby states.
- Manually tested creative inventory visibility and parser `/give` paths for related items/blocks.
- Manually tested Copper Chest related registration/integration paths.